### PR TITLE
Exclude unused files for smaller crate files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     - ubuntu-toolchain-r-test
     - kalakris-cmake
     packages:
-    - g++-4.9
+    - g++-7
     - cmake
     - libcurl4-openssl-dev
     - libelf-dev
@@ -27,8 +27,8 @@ install:
       fi
     - |
       if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-          export CC=gcc-4.9
-          export CXX=g++-4.9
+          export CC=gcc-7
+          export CXX=g++-7
       fi
     # Build and cache kcov
     - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Modern library for chemistry trajectories reading and writing"
 keywords = ["computational", "theoretical", "chemistry", "file", "trajectory"]
 readme = "README.md"
 license = "BSD-3-Clause"
+exclude = ["data/*"]
 
 [lib]
 name = "chemfiles"

--- a/chemfiles-sys-tests/build.rs
+++ b/chemfiles-sys-tests/build.rs
@@ -5,6 +5,9 @@ fn main() {
     cfg.header("chemfiles.h");
     cfg.include("../chemfiles-sys/chemfiles/include");
     cfg.include(".");
+    cfg.type_name(|ty, _is_struct| {
+        ty.to_string()
+    });
 
     cfg.skip_signededness(|s| s == "chfl_warning_callback" || s == "chfl_vector3d");
 

--- a/chemfiles-sys/Cargo.toml
+++ b/chemfiles-sys/Cargo.toml
@@ -6,6 +6,7 @@ links = "chemfiles"
 repository = "https://github.com/chemfiles/chemfiles.rs"
 license = "BSD-3-Clause"
 description = "Rust FFI declaration for the chemfiles library"
+exclude = ["chemfiles/tests/**"]
 
 [lib]
 name = "chemfiles_sys"


### PR DESCRIPTION
With this commit chemfiles.crate goes from 1.1M to 27K, and chemfiles-sys.crate from 3.7M to 2.0M.

This should speed-up fresh download when building chemfiles