### PR TITLE
fix: remove unnecessary casts of atom indices

### DIFF
--- a/examples/select.rs
+++ b/examples/select.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         to_remove.sort();
         to_remove.reverse();
         for i in to_remove {
-            frame.remove(i as usize);
+            frame.remove(i);
         }
 
         output.write(&frame)?;

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -4,7 +4,7 @@
 extern crate chemfiles;
 use chemfiles::{Frame, Selection, Trajectory};
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut input = Trajectory::open("input.arc", 'r')?;
     let mut output = Trajectory::open("output.pdb", 'w')?;
 

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -26,7 +26,6 @@ pub struct Atom {
 }
 
 /// An analog to a reference to an atom (`&Atom`)
-#[allow(clippy::stutter)]
 pub struct AtomRef<'a> {
     inner: Atom,
     marker: PhantomData<&'a Atom>
@@ -40,7 +39,6 @@ impl<'a> Deref for AtomRef<'a> {
 }
 
 /// An analog to a mutable reference to an atom (`&mut Atom`)
-#[allow(clippy::stutter)]
 pub struct AtomMut<'a> {
     inner: Atom,
     marker: PhantomData<&'a mut Atom>

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -8,7 +8,6 @@ use errors::{check_success, check_not_null, check, Error};
 
 /// Available unit cell shapes.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(clippy::stutter)]
 pub enum CellShape {
     /// Orthorhombic cell, with the three angles equals to 90°.
     Orthorhombic,
@@ -53,7 +52,6 @@ impl From<CellShape> for chfl_cellshape {
 /// |  0    b_y   c_y |
 /// |  0     0    c_z |
 /// ```
-#[allow(clippy::stutter)]
 pub struct UnitCell {
     handle: *mut CHFL_CELL,
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -216,9 +216,9 @@ impl Frame {
     /// assert_eq!(frame.size(), 2);
     /// assert_eq!(frame.atom(1).name(), "Sn");
     /// ```
-    pub fn remove(&mut self, i: usize) {
+    pub fn remove(&mut self, i: u64) {
         unsafe {
-            check_success(chfl_frame_remove(self.as_mut_ptr(), i as u64));
+            check_success(chfl_frame_remove(self.as_mut_ptr(), i));
         }
     }
 
@@ -290,10 +290,10 @@ impl Frame {
     /// let bonds = frame.topology().bonds();
     /// assert_eq!(bonds, vec![[0, 1], [1, 3]]);
     /// ```
-    pub fn remove_bond(&mut self, i: usize, j: usize) {
+    pub fn remove_bond(&mut self, i: u64, j: u64) {
         unsafe {
             check_success(chfl_frame_remove_bond(
-                self.as_mut_ptr(), i as u64, j as u64
+                self.as_mut_ptr(), i, j
             ));
         }
     }
@@ -335,11 +335,11 @@ impl Frame {
     ///
     /// assert_eq!(frame.distance(0, 1), f64::sqrt(14.0));
     /// ```
-    pub fn distance(&self, i: usize, j: usize) -> f64 {
+    pub fn distance(&self, i: u64, j: u64) -> f64 {
         let mut distance = 0.0;
         unsafe {
             check_success(chfl_frame_distance(
-                self.as_ptr(), i as u64, j as u64, &mut distance
+                self.as_ptr(), i, j, &mut distance
             ));
         }
         return distance;
@@ -360,11 +360,11 @@ impl Frame {
     ///
     /// assert_eq!(frame.angle(0, 1, 2), f64::consts::PI / 2.0);
     /// ```
-    pub fn angle(&self, i: usize, j: usize, k: usize) -> f64 {
+    pub fn angle(&self, i: u64, j: u64, k: u64) -> f64 {
         let mut angle = 0.0;
         unsafe {
             check_success(chfl_frame_angle(
-                self.as_ptr(), i as u64, j as u64, k as u64, &mut angle
+                self.as_ptr(), i, j, k, &mut angle
             ));
         }
         return angle;
@@ -386,15 +386,15 @@ impl Frame {
     ///
     /// assert_eq!(frame.dihedral(0, 1, 2, 3), f64::consts::PI / 2.0);
     /// ```
-    pub fn dihedral(&self, i: usize, j: usize, k: usize, m: usize) -> f64 {
+    pub fn dihedral(&self, i: u64, j: u64, k: u64, m: u64) -> f64 {
         let mut dihedral = 0.0;
         unsafe {
             check_success(chfl_frame_dihedral(
                 self.as_ptr(),
-                i as u64,
-                j as u64,
-                k as u64,
-                m as u64,
+                i,
+                j,
+                k,
+                m,
                 &mut dihedral
             ));
         }
@@ -419,15 +419,15 @@ impl Frame {
     ///
     /// assert_eq!(frame.out_of_plane(0, 1, 2, 3), 2.0);
     /// ```
-    pub fn out_of_plane(&self, i: usize, j: usize, k: usize, m: usize) -> f64 {
+    pub fn out_of_plane(&self, i: u64, j: u64, k: u64, m: u64) -> f64 {
         let mut distance = 0.0;
         unsafe {
             check_success(chfl_frame_out_of_plane(
                 self.as_ptr(),
-                i as u64,
-                j as u64,
-                k as u64,
-                m as u64,
+                i,
+                j,
+                k,
+                m,
                 &mut distance
             ));
         }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -405,7 +405,7 @@ impl Frame {
     /// `k` and `m` in this frame, accounting for periodic boundary conditions.
     /// The result is expressed in angstroms.
     ///
-    /// This is the distance betweent the atom j and the ikm plane. The j atom
+    /// This is the distance between the atom j and the ikm plane. The j atom
     /// is the center of the improper dihedral angle formed by i, j, k and m.
     ///
     /// # Example

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -95,11 +95,11 @@ impl Frame {
     /// let atom = frame.atom(0);
     /// assert_eq!(atom.name(), "Zn");
     /// ```
-    pub fn atom(&self, index: u64) -> AtomRef {
+    pub fn atom(&self, index: usize) -> AtomRef {
         unsafe {
             let handle = chfl_atom_from_frame(
                 self.as_mut_ptr_MANUALLY_CHECKING_BORROW(),
-                index
+                index as u64
             );
             Atom::ref_from_ptr(handle)
         }
@@ -122,9 +122,9 @@ impl Frame {
     /// frame.atom_mut(0).set_name("Fe");
     /// assert_eq!(frame.atom(0).name(), "Fe");
     /// ```
-    pub fn atom_mut(&mut self, index: u64) -> AtomMut {
+    pub fn atom_mut(&mut self, index: usize) -> AtomMut {
         unsafe {
-            let handle = chfl_atom_from_frame(self.as_mut_ptr(), index);
+            let handle = chfl_atom_from_frame(self.as_mut_ptr(), index as u64);
             Atom::ref_mut_from_ptr(handle)
         }
     }
@@ -140,12 +140,13 @@ impl Frame {
     /// frame.resize(67);
     /// assert_eq!(frame.size(), 67);
     /// ```
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         let mut size = 0;
         unsafe {
             check_success(chfl_frame_atoms_count(self.as_ptr(), &mut size));
         }
-        return size;
+        #[allow(clippy::cast_possible_truncation)]
+        return size as usize;
     }
 
     /// Resize the positions and the velocities in this frame, to make space for
@@ -159,9 +160,9 @@ impl Frame {
     /// frame.resize(67);
     /// assert_eq!(frame.size(), 67);
     /// ```
-    pub fn resize(&mut self, natoms: u64) {
+    pub fn resize(&mut self, natoms: usize) {
         unsafe {
-            check_success(chfl_frame_resize(self.as_mut_ptr(), natoms));
+            check_success(chfl_frame_resize(self.as_mut_ptr(), natoms as u64));
         }
     }
 
@@ -216,9 +217,9 @@ impl Frame {
     /// assert_eq!(frame.size(), 2);
     /// assert_eq!(frame.atom(1).name(), "Sn");
     /// ```
-    pub fn remove(&mut self, i: u64) {
+    pub fn remove(&mut self, i: usize) {
         unsafe {
-            check_success(chfl_frame_remove(self.as_mut_ptr(), i));
+            check_success(chfl_frame_remove(self.as_mut_ptr(), i as u64));
         }
     }
 
@@ -241,9 +242,9 @@ impl Frame {
     /// assert_eq!(frame.topology().bond_order(0, 1), BondOrder::Unknown);
     /// assert_eq!(frame.topology().bonds(), vec![[0, 1], [1, 3], [2, 4]]);
     /// ```
-    pub fn add_bond(&mut self, i: u64, j: u64) {
+    pub fn add_bond(&mut self, i: usize, j: usize) {
         unsafe {
-            check_success(chfl_frame_add_bond(self.as_mut_ptr(), i, j));
+            check_success(chfl_frame_add_bond(self.as_mut_ptr(), i as u64, j as u64));
         }
     }
 
@@ -260,10 +261,13 @@ impl Frame {
     /// frame.add_bond_with_order(0, 1, BondOrder::Double);
     /// assert_eq!(frame.topology().bond_order(0, 1), BondOrder::Double);
     /// ```
-    pub fn add_bond_with_order(&mut self, i: u64, j: u64, order: BondOrder) {
+    pub fn add_bond_with_order(&mut self, i: usize, j: usize, order: BondOrder) {
         unsafe {
             check_success(chfl_frame_bond_with_order(
-                self.as_mut_ptr(), i, j, order.as_raw()
+                self.as_mut_ptr(),
+                i as u64,
+                j as u64,
+                order.as_raw(),
             ));
         }
     }
@@ -290,10 +294,12 @@ impl Frame {
     /// let bonds = frame.topology().bonds();
     /// assert_eq!(bonds, vec![[0, 1], [1, 3]]);
     /// ```
-    pub fn remove_bond(&mut self, i: u64, j: u64) {
+    pub fn remove_bond(&mut self, i: usize, j: usize) {
         unsafe {
             check_success(chfl_frame_remove_bond(
-                self.as_mut_ptr(), i, j
+                self.as_mut_ptr(),
+                i as u64,
+                j as u64,
             ));
         }
     }
@@ -335,11 +341,14 @@ impl Frame {
     ///
     /// assert_eq!(frame.distance(0, 1), f64::sqrt(14.0));
     /// ```
-    pub fn distance(&self, i: u64, j: u64) -> f64 {
+    pub fn distance(&self, i: usize, j: usize) -> f64 {
         let mut distance = 0.0;
         unsafe {
             check_success(chfl_frame_distance(
-                self.as_ptr(), i, j, &mut distance
+                self.as_ptr(),
+                i as u64,
+                j as u64,
+                &mut distance,
             ));
         }
         return distance;
@@ -360,11 +369,15 @@ impl Frame {
     ///
     /// assert_eq!(frame.angle(0, 1, 2), f64::consts::PI / 2.0);
     /// ```
-    pub fn angle(&self, i: u64, j: u64, k: u64) -> f64 {
+    pub fn angle(&self, i: usize, j: usize, k: usize) -> f64 {
         let mut angle = 0.0;
         unsafe {
             check_success(chfl_frame_angle(
-                self.as_ptr(), i, j, k, &mut angle
+                self.as_ptr(),
+                i as u64,
+                j as u64,
+                k as u64,
+                &mut angle,
             ));
         }
         return angle;
@@ -386,16 +399,16 @@ impl Frame {
     ///
     /// assert_eq!(frame.dihedral(0, 1, 2, 3), f64::consts::PI / 2.0);
     /// ```
-    pub fn dihedral(&self, i: u64, j: u64, k: u64, m: u64) -> f64 {
+    pub fn dihedral(&self, i: usize, j: usize, k: usize, m: usize) -> f64 {
         let mut dihedral = 0.0;
         unsafe {
             check_success(chfl_frame_dihedral(
                 self.as_ptr(),
-                i,
-                j,
-                k,
-                m,
-                &mut dihedral
+                i as u64,
+                j as u64,
+                k as u64,
+                m as u64,
+                &mut dihedral,
             ));
         }
         return dihedral;
@@ -419,16 +432,16 @@ impl Frame {
     ///
     /// assert_eq!(frame.out_of_plane(0, 1, 2, 3), 2.0);
     /// ```
-    pub fn out_of_plane(&self, i: u64, j: u64, k: u64, m: u64) -> f64 {
+    pub fn out_of_plane(&self, i: usize, j: usize, k: usize, m: usize) -> f64 {
         let mut distance = 0.0;
         unsafe {
             check_success(chfl_frame_out_of_plane(
                 self.as_ptr(),
-                i,
-                j,
-                k,
-                m,
-                &mut distance
+                i as u64,
+                j as u64,
+                k as u64,
+                m as u64,
+                &mut distance,
             ));
         }
         return distance;
@@ -694,12 +707,13 @@ impl Frame {
     /// let frame = Frame::new();
     /// assert_eq!(frame.step(), 0);
     /// ```
-    pub fn step(&self) -> u64 {
+    pub fn step(&self) -> usize {
         let mut step = 0;
         unsafe {
             check_success(chfl_frame_step(self.as_ptr(), &mut step));
         }
-        return step;
+        #[allow(clippy::cast_possible_truncation)]
+        return step as usize;
     }
 
     /// Set this frame step to `step`.
@@ -713,9 +727,9 @@ impl Frame {
     /// frame.set_step(10);
     /// assert_eq!(frame.step(), 10);
     /// ```
-    pub fn set_step(&mut self, step: u64) {
+    pub fn set_step(&mut self, step: usize) {
         unsafe {
-            check_success(chfl_frame_set_step(self.as_mut_ptr(), step));
+            check_success(chfl_frame_set_step(self.as_mut_ptr(), step as u64));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,17 @@
 
 //! Chemfiles is a multi-language library written in modern C++ for reading and
 //! writing from and to molecular trajectory files. These files are created by
-//! your favorite theoretical chemistry program, and contains informations about
+//! your favorite theoretical chemistry program, and contains information about
 //! atomic or residues names and positions. Some format also have additional
-//! informations, such as velocities, forces, energy, …
+//! information, such as velocities, forces, energy, …
 //!
 //! This crate expose the C API of chemfiles to Rust, and make all the
-//! functionalities accessibles. For more informations on the C++ library,
+//! functionalities accessible. For more information on the C++ library,
 //! please see its [documentation][cxx_doc]. Specifically, the following pages
 //! are worth reading:
 //!
 //! - The [overview][overview] of the classes organisation;
-//! - The lisf of [supported formats][formats];
+//! - The list of [supported formats][formats];
 //! - The documentation for the [selection language][selections];
 //!
 //! [cxx_doc]: https://chemfiles.org/chemfiles
@@ -28,6 +28,7 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::needless_return, clippy::redundant_field_names, clippy::use_self)]
 #![allow(clippy::missing_docs_in_private_items, clippy::or_fun_call, clippy::indexing_slicing)]
+#![allow(clippy::module_name_repetitions)]
 
 // deny(warnings) in doc tests
 #![doc(test(attr(deny(warnings))))]
@@ -97,7 +98,7 @@ pub fn version() -> String {
 /// to add data from another configuration file.
 ///
 /// This function will fail if there is no file at `path`, or if the file is
-/// incorectly formatted. Data from the new configuration file will overwrite
+/// incorrectly formatted. Data from the new configuration file will overwrite
 /// any existing data.
 ///
 /// # Example

--- a/src/residue.rs
+++ b/src/residue.rs
@@ -2,7 +2,6 @@
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
 use std::ops::{Drop, Deref};
 use std::marker::PhantomData;
-use std::u64;
 use std::ptr;
 
 use chemfiles_sys::*;
@@ -123,12 +122,13 @@ impl Residue {
     /// residue.add_atom(2);
     /// assert_eq!(residue.size(), 3);
     /// ```
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> usize {
         let mut size = 0;
         unsafe {
             check_success(chfl_residue_atoms_count(self.as_ptr(), &mut size));
         }
-        return size;
+        #[allow(clippy::cast_possible_truncation)]
+        return size as usize;
     }
 
     /// Get the identifier of this residue in the initial topology file.
@@ -187,9 +187,9 @@ impl Residue {
     /// residue.add_atom(56);
     /// assert_eq!(residue.size(), 1);
     /// ```
-    pub fn add_atom(&mut self, atom: u64) {
+    pub fn add_atom(&mut self, atom: usize) {
         unsafe {
-            check_success(chfl_residue_add_atom(self.as_mut_ptr(), atom));
+            check_success(chfl_residue_add_atom(self.as_mut_ptr(), atom as u64));
         }
     }
 
@@ -204,10 +204,10 @@ impl Residue {
     /// residue.add_atom(56);
     /// assert_eq!(residue.contains(56), true);
     /// ```
-    pub fn contains(&self, atom: u64) -> bool {
+    pub fn contains(&self, atom: usize) -> bool {
         let mut inside = 0;
         unsafe {
-            check_success(chfl_residue_contains(self.as_ptr(), atom, &mut inside));
+            check_success(chfl_residue_contains(self.as_ptr(), atom as u64, &mut inside));
         }
         return inside != 0;
     }

--- a/src/residue.rs
+++ b/src/residue.rs
@@ -18,7 +18,6 @@ pub struct Residue {
 }
 
 /// An analog to a reference to a residue (`&Residue`)
-#[allow(clippy::stutter)]
 pub struct ResidueRef<'a> {
     inner: Residue,
     marker: PhantomData<&'a Residue>

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -179,8 +179,8 @@ impl Selection {
     /// together.
     ///
     /// This value is 1 for the 'atom' context, 2 for the 'pair' and 'bond'
-    /// context, 3 for the 'three' and 'angles' contextes and 4 for the 'four'
-    /// and 'dihedral' contextes.
+    /// context, 3 for the 'three' and 'angles' context and 4 for the 'four'
+    /// and 'dihedral' context.
     ///
     /// # Example
     /// ```

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,7 +1,7 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
 
-//! String convertions between C and Rust
+//! String conversions between C and Rust
 use std::ffi::{CStr, CString};
 use std::str;
 

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -72,7 +72,6 @@ pub struct Topology {
 }
 
 /// An analog to a reference to a topology (`&Topology`)
-#[allow(clippy::stutter)]
 pub struct TopologyRef<'a> {
     inner: Topology,
     marker: PhantomData<&'a Topology>

--- a/src/trajectory.rs
+++ b/src/trajectory.rs
@@ -136,9 +136,9 @@ impl Trajectory {
     ///
     /// trajectory.read_step(10, &mut frame).unwrap();
     /// ```
-    pub fn read_step(&mut self, step: u64, frame: &mut Frame) -> Result<(), Error> {
+    pub fn read_step(&mut self, step: usize, frame: &mut Frame) -> Result<(), Error> {
         unsafe {
-            check(chfl_trajectory_read_step(self.as_mut_ptr(), step, frame.as_mut_ptr()))
+            check(chfl_trajectory_read_step(self.as_mut_ptr(), step as u64, frame.as_mut_ptr()))
         }
     }
 
@@ -258,12 +258,13 @@ impl Trajectory {
     /// ```
     // FIXME should this take &self instead? The file can be modified by this
     // function, but the format should reset the state.
-    pub fn nsteps(&mut self) -> Result<u64, Error> {
+    pub fn nsteps(&mut self) -> Result<usize, Error> {
         let mut res = 0;
         unsafe {
             check(chfl_trajectory_nsteps(self.as_mut_ptr(), &mut res))?;
         }
-        Ok(res)
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(res as usize)
     }
 
     /// Get file path for this trajectory.


### PR DESCRIPTION
Some small changes:
- Atom indices are usually given as `u64` but some functions expected `usize` and then immediately cast the parameter to `u64`.
- clippy got an update: `stutter` is [deprecated](https://github.com/rust-lang/rust-clippy/pull/3554)
- Since most structs contain the module name and the name is somewhat set, because this is mostly just a wrapper, IMHO it is reasonable to allow `module_name_repetitions` globally, isn't it?

BTW: Should we run `rustfmt`on all the files?