### PR TITLE
fix: check used function is a substring of other function name

### DIFF
--- a/scripts/check-used-functions.py
+++ b/scripts/check-used-functions.py
@@ -5,6 +5,7 @@ effectivelly used in the chemfiles binding.
 """
 import os
 import sys
+import re
 
 ERROR = False
 ROOT = os.path.join(os.path.dirname(__file__), "..")
@@ -33,25 +34,27 @@ def functions_list():
     return functions
 
 
-def read_all_source():
-    source = ""
+def read_all_binding_functions():
+    binding_functions = set()
     for (dirpath, _, pathes) in os.walk(os.path.join(ROOT, "src")):
         for path in pathes:
             with open(os.path.join(ROOT, dirpath, path)) as fd:
-                source += fd.read()
-    return source
+                # https://doc.rust-lang.org/nightly/reference/identifiers.html
+                file_functions = re.findall(r"(chfl_[a-z A-Z 0-9 _]*)\(", fd.read())
+                binding_functions.update(file_functions)
+    return binding_functions
 
 
-def check_functions(functions, source):
+def check_functions(functions, binding_functions):
     for function in functions:
-        if function not in source:
+        if function not in binding_functions:
             error("Missing: " + function)
 
 
 if __name__ == '__main__':
     functions = functions_list()
-    source = read_all_source()
-    check_functions(functions, source)
+    binding_functions = read_all_binding_functions()
+    check_functions(functions, binding_functions)
 
     if ERROR:
         sys.exit(1)

--- a/scripts/check-used-functions.py
+++ b/scripts/check-used-functions.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 """
 Check that all the functions defined in the chemfiles-sys crate are
-effectivelly used in the chemfiles binding.
+effectively used in the chemfiles binding.
 """
 import os
 import sys
 import re
 
 ERROR = False
-ROOT = os.path.join(os.path.dirname(__file__), "..")
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
 
 
 def error(message):
@@ -36,8 +36,8 @@ def functions_list():
 
 def read_all_binding_functions():
     binding_functions = set()
-    for (dirpath, _, pathes) in os.walk(os.path.join(ROOT, "src")):
-        for path in pathes:
+    for (dirpath, _, paths) in os.walk(os.path.join(ROOT, "src")):
+        for path in paths:
             with open(os.path.join(ROOT, dirpath, path)) as fd:
                 # https://doc.rust-lang.org/nightly/reference/identifiers.html
                 file_functions = re.findall(r"(chfl_[a-z A-Z 0-9 _]*)\(", fd.read())


### PR DESCRIPTION
If a function name is a substring of an other function name it is marked as implemented although it is not. E.g. `chfl_residue_atoms` is not implemented but `chfl_residue_atoms_count` is. The script `check-used-functions.py` does not throw an error because it finds `chfl_residue_atoms` as substring of `chfl_residue_atoms_count`.

This PR checks against full function names not just substrings. Those function names must start with `chfl_` followed by a sequence of [valid rust identifier chars](https://doc.rust-lang.org/nightly/reference/identifiers.html) and must end with `(`. This last bracket is not part of the name.

This is probably something that we want to change in all other language bindings. (Julia seems to be the only other binding that misses a function, as far as I can tell.)