### PR TITLE
Maintenance: make sure chemfiles-sys is generated from the header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chemfiles-sys = {path = "chemfiles-sys", version = "0.10.0"}
 libc = "0.2"
 
 [dev-dependencies]
-approx = "0.3"
+approx = "0.4"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chemfiles.rs
 
-[![Build Status](https://travis-ci.org/chemfiles/chemfiles.rs.svg?branch=master)](https://travis-ci.org/chemfiles/chemfiles.rs)
+![Test status](https://github.com/chemfiles/chemfiles.rs/workflows/Test/badge.svg)
 [![codecov.io](https://codecov.io/github/chemfiles/chemfiles.rs/coverage.svg?branch=master)](https://codecov.io/github/chemfiles/chemfiles.rs?branch=master)
 [![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](http://chemfiles.org/chemfiles.rs/)
 

--- a/chemfiles-sys/lib.rs
+++ b/chemfiles-sys/lib.rs
@@ -1,5 +1,11 @@
 // Chemfiles.rs, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
+//
+// ========================================================================= //
+//                       !!!! AUTO-GENERATED FILE !!!!
+// Do not edit. See the bindgen repository for the generation code
+//                   https://github.com/chemfiles/bindgen
+// ========================================================================= //
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
@@ -18,6 +24,24 @@ pub type chfl_vector3d = [c_double; 3];
 pub struct chfl_match {
     pub size: u64,
     pub atoms: [u64; 4],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct chfl_format_metadata {
+    pub name: *const c_char,
+    pub extension: *const c_char,
+    pub description: *const c_char,
+    pub reference: *const c_char,
+    pub read: bool,
+    pub write: bool,
+    pub memory: bool,
+    pub positions: bool,
+    pub velocities: bool,
+    pub unit_cell: bool,
+    pub atoms: bool,
+    pub bonds: bool,
+    pub residues: bool,
 }
 // End manual definitions
 
@@ -55,7 +79,7 @@ pub enum chfl_bond_order {
     CHFL_BOND_DOUBLE = 2,
     CHFL_BOND_TRIPLE = 3,
     CHFL_BOND_QUADRUPLE = 4,
-    CHFL_BOND_QINTUPLET = 5,
+    CHFL_BOND_QUINTUPLET = 5,
     CHFL_BOND_AMIDE = 254,
     CHFL_BOND_AROMATIC = 255,
 }
@@ -79,32 +103,15 @@ pub enum chfl_cellshape {
     CHFL_CELL_INFINITE = 2,
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct chfl_format_metadata {
-    pub name: *const c_char,
-    pub extension: *const c_char,
-    pub description: *const c_char,
-    pub reference: *const c_char,
-    pub read: bool,
-    pub write: bool,
-    pub memory: bool,
-    pub positions: bool,
-    pub velocities: bool,
-    pub unit_cell: bool,
-    pub atoms: bool,
-    pub bonds: bool,
-    pub residues: bool,
-}
-
 #[link(name="chemfiles", kind="static")]
 extern "C" {
     pub fn chfl_version() -> *const c_char;
-    pub fn chfl_free(objet: *const c_void) -> c_void;
     pub fn chfl_last_error() -> *const c_char;
     pub fn chfl_clear_errors() -> chfl_status;
     pub fn chfl_set_warning_callback(callback: chfl_warning_callback) -> chfl_status;
     pub fn chfl_add_configuration(path: *const c_char) -> chfl_status;
+    pub fn chfl_formats_list(metadata: *mut *mut chfl_format_metadata, count: *mut u64) -> chfl_status;
+    pub fn chfl_free(object: *const c_void) -> c_void;
     pub fn chfl_property_bool(value: c_bool) -> *mut CHFL_PROPERTY;
     pub fn chfl_property_double(value: c_double) -> *mut CHFL_PROPERTY;
     pub fn chfl_property_string(value: *const c_char) -> *mut CHFL_PROPERTY;
@@ -140,7 +147,7 @@ extern "C" {
     pub fn chfl_residue_for_atom(topology: *const CHFL_TOPOLOGY, i: u64) -> *const CHFL_RESIDUE;
     pub fn chfl_residue_copy(residue: *const CHFL_RESIDUE) -> *mut CHFL_RESIDUE;
     pub fn chfl_residue_atoms_count(residue: *const CHFL_RESIDUE, count: *mut u64) -> chfl_status;
-    pub fn chfl_residue_atoms(residue: *const CHFL_RESIDUE, atoms: *mut u64, natoms: u64) -> chfl_status;
+    pub fn chfl_residue_atoms(residue: *const CHFL_RESIDUE, atoms: *mut u64, count: u64) -> chfl_status;
     pub fn chfl_residue_id(residue: *const CHFL_RESIDUE, id: *mut i64) -> chfl_status;
     pub fn chfl_residue_name(residue: *const CHFL_RESIDUE, name: *mut c_char, buffsize: u64) -> chfl_status;
     pub fn chfl_residue_add_atom(residue: *mut CHFL_RESIDUE, i: u64) -> chfl_status;
@@ -164,9 +171,9 @@ extern "C" {
     pub fn chfl_topology_angles(topology: *const CHFL_TOPOLOGY, data: *mut [u64; 3], count: u64) -> chfl_status;
     pub fn chfl_topology_dihedrals(topology: *const CHFL_TOPOLOGY, data: *mut [u64; 4], count: u64) -> chfl_status;
     pub fn chfl_topology_impropers(topology: *const CHFL_TOPOLOGY, data: *mut [u64; 4], count: u64) -> chfl_status;
-    pub fn chfl_topology_clear_bonds(topology: *mut CHFL_TOPOLOGY) -> chfl_status;
     pub fn chfl_topology_add_bond(topology: *mut CHFL_TOPOLOGY, i: u64, j: u64) -> chfl_status;
     pub fn chfl_topology_remove_bond(topology: *mut CHFL_TOPOLOGY, i: u64, j: u64) -> chfl_status;
+    pub fn chfl_topology_clear_bonds(topology: *mut CHFL_TOPOLOGY) -> chfl_status;
     pub fn chfl_topology_residues_count(topology: *const CHFL_TOPOLOGY, count: *mut u64) -> chfl_status;
     pub fn chfl_topology_add_residue(topology: *mut CHFL_TOPOLOGY, residue: *const CHFL_RESIDUE) -> chfl_status;
     pub fn chfl_topology_residues_linked(topology: *const CHFL_TOPOLOGY, first: *const CHFL_RESIDUE, second: *const CHFL_RESIDUE, result: *mut c_bool) -> chfl_status;
@@ -174,7 +181,7 @@ extern "C" {
     pub fn chfl_topology_bond_orders(topology: *const CHFL_TOPOLOGY, orders: *mut chfl_bond_order, nbonds: u64) -> chfl_status;
     pub fn chfl_topology_bond_order(topology: *const CHFL_TOPOLOGY, i: u64, j: u64, order: *mut chfl_bond_order) -> chfl_status;
     pub fn chfl_cell(lengths: *const c_double, angles: *const c_double) -> *mut CHFL_CELL;
-    pub fn chfl_cell_from_matrix(matrix: *const [c_double; 3]) -> *mut CHFL_CELL;
+    pub fn chfl_cell_from_matrix(matrix: *mut [c_double; 3]) -> *mut CHFL_CELL;
     pub fn chfl_cell_from_frame(frame: *mut CHFL_FRAME) -> *mut CHFL_CELL;
     pub fn chfl_cell_copy(cell: *const CHFL_CELL) -> *mut CHFL_CELL;
     pub fn chfl_cell_volume(cell: *const CHFL_CELL, volume: *mut c_double) -> chfl_status;
@@ -201,7 +208,6 @@ extern "C" {
     pub fn chfl_frame_step(frame: *const CHFL_FRAME, step: *mut u64) -> chfl_status;
     pub fn chfl_frame_set_step(frame: *mut CHFL_FRAME, step: u64) -> chfl_status;
     pub fn chfl_frame_guess_bonds(frame: *mut CHFL_FRAME) -> chfl_status;
-    pub fn chfl_frame_clear_bonds(frame: *mut CHFL_FRAME) -> chfl_status;
     pub fn chfl_frame_distance(frame: *const CHFL_FRAME, i: u64, j: u64, distance: *mut c_double) -> chfl_status;
     pub fn chfl_frame_angle(frame: *const CHFL_FRAME, i: u64, j: u64, k: u64, angle: *mut c_double) -> chfl_status;
     pub fn chfl_frame_dihedral(frame: *const CHFL_FRAME, i: u64, j: u64, k: u64, m: u64, dihedral: *mut c_double) -> chfl_status;
@@ -213,10 +219,11 @@ extern "C" {
     pub fn chfl_frame_add_bond(frame: *mut CHFL_FRAME, i: u64, j: u64) -> chfl_status;
     pub fn chfl_frame_bond_with_order(frame: *mut CHFL_FRAME, i: u64, j: u64, bond_order: chfl_bond_order) -> chfl_status;
     pub fn chfl_frame_remove_bond(frame: *mut CHFL_FRAME, i: u64, j: u64) -> chfl_status;
+    pub fn chfl_frame_clear_bonds(frame: *mut CHFL_FRAME) -> chfl_status;
     pub fn chfl_frame_add_residue(frame: *mut CHFL_FRAME, residue: *const CHFL_RESIDUE) -> chfl_status;
     pub fn chfl_trajectory_open(path: *const c_char, mode: c_char) -> *mut CHFL_TRAJECTORY;
     pub fn chfl_trajectory_with_format(path: *const c_char, mode: c_char, format: *const c_char) -> *mut CHFL_TRAJECTORY;
-    pub fn chfl_trajectory_memory_reader(data: *const c_char, size: u64, format: *const c_char) -> *mut CHFL_TRAJECTORY;
+    pub fn chfl_trajectory_memory_reader(memory: *const c_char, size: u64, format: *const c_char) -> *mut CHFL_TRAJECTORY;
     pub fn chfl_trajectory_memory_writer(format: *const c_char) -> *mut CHFL_TRAJECTORY;
     pub fn chfl_trajectory_path(trajectory: *const CHFL_TRAJECTORY, path: *mut c_char, buffsize: u64) -> chfl_status;
     pub fn chfl_trajectory_read(trajectory: *mut CHFL_TRAJECTORY, frame: *mut CHFL_FRAME) -> chfl_status;
@@ -226,7 +233,7 @@ extern "C" {
     pub fn chfl_trajectory_topology_file(trajectory: *mut CHFL_TRAJECTORY, path: *const c_char, format: *const c_char) -> chfl_status;
     pub fn chfl_trajectory_set_cell(trajectory: *mut CHFL_TRAJECTORY, cell: *const CHFL_CELL) -> chfl_status;
     pub fn chfl_trajectory_nsteps(trajectory: *mut CHFL_TRAJECTORY, nsteps: *mut u64) -> chfl_status;
-    pub fn chfl_trajectory_memory_buffer(trajectory: *const CHFL_TRAJECTORY, data: *mut *const c_char, max_size: *mut u64) -> chfl_status;
+    pub fn chfl_trajectory_memory_buffer(trajectory: *const CHFL_TRAJECTORY, data: *mut *const c_char, size: *mut u64) -> chfl_status;
     pub fn chfl_trajectory_close(trajectory: *const CHFL_TRAJECTORY) -> c_void;
     pub fn chfl_selection(selection: *const c_char) -> *mut CHFL_SELECTION;
     pub fn chfl_selection_copy(selection: *const CHFL_SELECTION) -> *mut CHFL_SELECTION;
@@ -234,5 +241,4 @@ extern "C" {
     pub fn chfl_selection_string(selection: *const CHFL_SELECTION, string: *mut c_char, buffsize: u64) -> chfl_status;
     pub fn chfl_selection_evaluate(selection: *mut CHFL_SELECTION, frame: *const CHFL_FRAME, n_matches: *mut u64) -> chfl_status;
     pub fn chfl_selection_matches(selection: *const CHFL_SELECTION, matches: *mut chfl_match, n_matches: u64) -> chfl_status;
-    pub fn chfl_formats_list(metadata: *mut *mut chfl_format_metadata, count: *mut u64) -> chfl_status;
 }

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         input.read(&mut frame)?;
 
         let mut to_remove = selection.list(&frame)?;
-        to_remove.sort();
+        to_remove.sort_unstable();
         to_remove.reverse();
         for i in to_remove {
             frame.remove(i);

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -11,10 +11,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut selection = Selection::new("name Zn or name N")?;
 
     let mut frame = Frame::new();
-    for _ in 0..input.nsteps()? {
+    for _ in 0..input.nsteps() {
         input.read(&mut frame)?;
 
-        let mut to_remove = selection.list(&frame)?;
+        let mut to_remove = selection.list(&frame);
         to_remove.sort_unstable();
         to_remove.reverse();
         for i in to_remove {

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -247,7 +247,9 @@ impl UnitCell {
 
     /// Set the three lengths of the cell, in Angstroms.
     ///
-    /// This fails if the unit cell is infinite
+    /// # Errors
+    ///
+    /// This function fails if the unit cell is infinite
     ///
     /// # Example
     /// ```
@@ -287,8 +289,11 @@ impl UnitCell {
         return angles;
     }
 
-    /// Set the three angles of the cell, in degrees. This is only possible
-    /// with `Triclinic` cells.
+    /// Set the three angles of the cell, in degrees.
+    ///
+    /// # Errors
+    ///
+    /// This function fails if the unit cell is not `Triclinic`.
     ///
     /// # Example
     /// ```
@@ -358,6 +363,8 @@ impl UnitCell {
     }
 
     /// Set the shape of the unit cell to `shape`.
+    ///
+    /// # Errors
     ///
     /// This can fail if the cell length or angles are incompatible with the
     /// new shape.

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -211,6 +211,11 @@ impl UnitCell {
     /// matrix is non-zero, then the cell is `Orthorhombic`. Else a
     /// `Triclinic` cell is created. The matrix entries should be in Angstroms.
     ///
+    /// # Panics
+    ///
+    /// If the matrix has a negative determinant, or more generally is not
+    /// representing a unit cell.
+    ///
     /// # Example
     /// ```
     /// # use chemfiles::{UnitCell, CellShape};
@@ -249,7 +254,8 @@ impl UnitCell {
     ///
     /// # Errors
     ///
-    /// This function fails if the unit cell is infinite
+    /// This function fails if the unit cell is infinite, or if one of the
+    /// lengths is negative.
     ///
     /// # Example
     /// ```

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -222,9 +222,9 @@ impl UnitCell {
     /// assert_eq!(cell.angles(), [90.0, 90.0, 90.0]);
     /// assert_eq!(cell.shape(), CellShape::Orthorhombic);
     /// ```
-    pub fn from_matrix(matrix: [[f64; 3]; 3]) -> UnitCell {
+    pub fn from_matrix(mut matrix: [[f64; 3]; 3]) -> UnitCell {
         unsafe {
-            let handle = chfl_cell_from_matrix(matrix.as_ptr());
+            let handle = chfl_cell_from_matrix(matrix.as_mut_ptr());
             UnitCell::from_ptr(handle)
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,8 +21,9 @@ pub struct Error {
     pub message: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq)]
 /// Possible causes of error in chemfiles
 pub enum Status {
     /// No error
@@ -47,8 +48,6 @@ pub enum Status {
     StdCppError = chfl_status::CHFL_CXX_ERROR as isize,
     /// The given path is not valid UTF8
     UTF8PathError,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl From<chfl_status> for Error {
@@ -117,10 +116,10 @@ pub(crate) fn check_not_null<T>(ptr: *const T) {
     }
 }
 
-pub trait WarningCallback: RefUnwindSafe + Fn(&str) -> () {}
+pub trait WarningCallback: RefUnwindSafe + Fn(&str) {}
 impl<T> WarningCallback for T
 where
-    T: RefUnwindSafe + Fn(&str) -> (),
+    T: RefUnwindSafe + Fn(&str),
 {
 }
 
@@ -177,7 +176,6 @@ impl error::Error for Error {
             Status::ConfigurationError => "Error in configuration files",
             Status::OutOfBounds => "Out of bounds indexing",
             Status::PropertyError => "Error in property",
-            _ => "unsupported error code",
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -64,9 +64,11 @@ impl From<chfl_status> for Error {
             chfl_status::CHFL_OUT_OF_BOUNDS => Status::OutOfBounds,
             chfl_status::CHFL_PROPERTY_ERROR => Status::PropertyError,
         };
+
+        let message = Error::last_error();
         Error {
-            status: status,
-            message: Error::last_error(),
+            status,
+            message,
         }
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -919,7 +919,7 @@ mod test {
         assert_eq!(frame.size(), 1);
         assert_eq!(frame.atom(0).name(), "U");
 
-        let positions: &[[f64; 3]] = &[[1.0, 1.0, 2.0]];
+        let positions = &[[1.0, 1.0, 2.0]];
         assert_eq!(frame.positions(), positions);
 
         frame.add_velocities();
@@ -928,10 +928,10 @@ mod test {
         assert_eq!(frame.atom(0).name(), "U");
         assert_eq!(frame.atom(1).name(), "F");
 
-        let positions: &[[f64; 3]] = &[[1.0, 1.0, 2.0], [1.0, 1.0, 2.0]];
+        let positions = &[[1.0, 1.0, 2.0], [1.0, 1.0, 2.0]];
         assert_eq!(frame.positions(), positions);
 
-        let velocities: &[[f64; 3]] = &[[0.0, 0.0, 0.0], [4.0, 3.0, 2.0]];
+        let velocities = &[[0.0, 0.0, 0.0], [4.0, 3.0, 2.0]];
         assert_eq!(frame.velocities(), velocities);
     }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -306,8 +306,10 @@ impl Frame {
 
     /// Add a copy of `residue` to this frame.
     ///
-    /// The residue id must not already be in this frame's topology, and the
-    /// residue must contain only atoms that are not already in another
+    /// # Errors
+    ///
+    /// This function fails is the residue id is already in this frame's
+    /// topology, or if the residue contain atoms that are already in another
     /// residue.
     ///
     /// # Example
@@ -676,8 +678,12 @@ impl Frame {
         }
     }
 
-    /// Set the `Topology` of this frame to `topology`. The topology must
-    /// contain the same number of atoms that this frame.
+    /// Set the `Topology` of this frame to `topology`.
+    ///
+    /// # Errors
+    ///
+    /// This function fails if the topology contains a different number of atoms
+    /// than this frame.
     ///
     /// # Example
     /// ```
@@ -738,8 +744,10 @@ impl Frame {
     /// The bonds are guessed using a distance-based algorithm, and then angles
     /// and dihedrals are guessed from the bonds.
     ///
-    /// This can fail if the covalent radius is unknown for some atoms in the
-    /// frame.
+    /// # Errors
+    ////
+    /// This function can fail if the covalent radius is unknown for some atoms
+    /// in the frame.
     ///
     /// # Example
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! please see its [documentation][cxx_doc]. Specifically, the following pages
 //! are worth reading:
 //!
-//! - The [overview][overview] of the classes organisation;
+//! - The [overview][overview] of the classes organization;
 //! - The list of [supported formats][formats];
 //! - The documentation for the [selection language][selections];
 //!
@@ -30,7 +30,6 @@
 #![allow(clippy::missing_docs_in_private_items, clippy::or_fun_call, clippy::indexing_slicing)]
 #![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 #![allow(clippy::wildcard_imports, clippy::unreadable_literal, clippy::shadow_unrelated)]
-#![allow(clippy::missing_errors_doc)]
 
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
@@ -100,13 +99,15 @@ pub fn version() -> String {
 
 /// Read configuration data from the file at `path`.
 ///
-/// By default, chemfiles reads configuration from any file named `.chemfiles.toml`
-/// in the current directory or any parent directory. This function can be used
-/// to add data from another configuration file.
+/// By default, chemfiles reads configuration from any file named
+/// `.chemfiles.toml` in the current directory or any parent directory. This
+/// function can be used to add data from another configuration file. Data from
+/// the new configuration file will overwrite any existing data.
+///
+/// # Errors
 ///
 /// This function will fail if there is no file at `path`, or if the file is
-/// incorrectly formatted. Data from the new configuration file will overwrite
-/// any existing data.
+/// incorrectly formatted.
 ///
 /// # Example
 /// ```no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,11 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::needless_return, clippy::redundant_field_names, clippy::use_self)]
 #![allow(clippy::missing_docs_in_private_items, clippy::or_fun_call, clippy::indexing_slicing)]
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
+#![allow(clippy::wildcard_imports, clippy::unreadable_literal, clippy::shadow_unrelated)]
+#![allow(clippy::missing_errors_doc)]
+
+#![cfg_attr(test, allow(clippy::float_cmp))]
 
 // deny(warnings) in doc tests
 #![doc(test(attr(deny(warnings))))]
@@ -96,7 +100,7 @@ pub fn version() -> String {
 
 /// Read configuration data from the file at `path`.
 ///
-/// By default, chemfiles reads configuration from any file name `.chemfilesrc`
+/// By default, chemfiles reads configuration from any file named `.chemfiles.toml`
 /// in the current directory or any parent directory. This function can be used
 /// to add data from another configuration file.
 ///
@@ -123,8 +127,8 @@ where
 mod tests {
     #[test]
     fn version() {
-        assert!(::version().len() > 0);
-        assert!(::version().starts_with("0.10"));
+        assert!(!crate::version().is_empty());
+        assert!(crate::version().starts_with("0.10"));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,11 @@
 #![warn(unused_qualifications, unused_results)]
 // Configuration for clippy lints
 #![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::needless_return, clippy::redundant_field_names, clippy::use_self)]
-#![allow(clippy::missing_docs_in_private_items, clippy::or_fun_call, clippy::indexing_slicing)]
-#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
-#![allow(clippy::wildcard_imports, clippy::unreadable_literal, clippy::shadow_unrelated)]
+#![allow(clippy::needless_return, clippy::module_name_repetitions)]
+#![allow(clippy::must_use_candidate, clippy::wildcard_imports)]
 
-#![cfg_attr(test, allow(clippy::float_cmp))]
+// Allow a few more clippy lints in test mode
+#![cfg_attr(test, allow(clippy::float_cmp, clippy::unreadable_literal, clippy::shadow_unrelated))]
 
 // deny(warnings) in doc tests
 #![doc(test(attr(deny(warnings))))]

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -353,10 +353,8 @@ mod tests {
             assert_eq!(match_.iter().cloned().collect::<Vec<usize>>(), vec![1, 2, 3, 4]);
 
             let v = vec![1, 2, 3, 4];
-            let mut i = 0;
-            for &m in &match_ {
+            for (i, &m) in match_.iter().enumerate() {
                 assert_eq!(v[i], m);
-                i += 1;
             }
         }
 
@@ -406,7 +404,7 @@ mod tests {
         let mut selection = Selection::new("angles: all").unwrap();
         let res = selection.evaluate(&frame).unwrap();
         for m in &[Match::new(&[0, 1, 2]), Match::new(&[1, 2, 3])] {
-            assert!(res.iter().find(|&r| r == m).is_some())
+            assert!(res.iter().any(|r| r == m))
         }
     }
 

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -23,8 +23,8 @@ pub enum BondOrder {
     Triple = chfl_bond_order::CHFL_BOND_TRIPLE as isize,
     /// Quadruple bond (present in some metals)
     Quadruple = chfl_bond_order::CHFL_BOND_QUADRUPLE as isize,
-    /// Qintuplet bond (present in some metals)
-    Qintuplet = chfl_bond_order::CHFL_BOND_QINTUPLET as isize,
+    /// Quintuplet bond (present in some metals)
+    Quintuplet = chfl_bond_order::CHFL_BOND_QUINTUPLET as isize,
     /// Amide bond (required by some file formats)
     Amide = chfl_bond_order::CHFL_BOND_AMIDE as isize,
     /// Aromatic bond (required by some file formats)
@@ -39,7 +39,7 @@ impl BondOrder {
             BondOrder::Double => chfl_bond_order::CHFL_BOND_DOUBLE,
             BondOrder::Triple => chfl_bond_order::CHFL_BOND_TRIPLE,
             BondOrder::Quadruple => chfl_bond_order::CHFL_BOND_QUADRUPLE,
-            BondOrder::Qintuplet => chfl_bond_order::CHFL_BOND_QINTUPLET,
+            BondOrder::Quintuplet => chfl_bond_order::CHFL_BOND_QUINTUPLET,
             BondOrder::Amide => chfl_bond_order::CHFL_BOND_AMIDE,
             BondOrder::Aromatic => chfl_bond_order::CHFL_BOND_AROMATIC,
         }
@@ -54,7 +54,7 @@ impl From<chfl_bond_order> for BondOrder {
             chfl_bond_order::CHFL_BOND_DOUBLE => BondOrder::Double,
             chfl_bond_order::CHFL_BOND_TRIPLE => BondOrder::Triple,
             chfl_bond_order::CHFL_BOND_QUADRUPLE => BondOrder::Quadruple,
-            chfl_bond_order::CHFL_BOND_QINTUPLET => BondOrder::Qintuplet,
+            chfl_bond_order::CHFL_BOND_QUINTUPLET => BondOrder::Quintuplet,
             chfl_bond_order::CHFL_BOND_AMIDE => BondOrder::Amide,
             chfl_bond_order::CHFL_BOND_AROMATIC => BondOrder::Aromatic,
         }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -10,6 +10,7 @@ use super::{Residue, ResidueRef};
 
 /// Possible bond order associated with bonds
 #[repr(C)]
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BondOrder {
     /// Unknown or unspecified bond order
@@ -28,8 +29,6 @@ pub enum BondOrder {
     Amide = chfl_bond_order::CHFL_BOND_AMIDE as isize,
     /// Aromatic bond (required by some file formats)
     Aromatic = chfl_bond_order::CHFL_BOND_AROMATIC as isize,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl BondOrder {
@@ -43,7 +42,6 @@ impl BondOrder {
             BondOrder::Qintuplet => chfl_bond_order::CHFL_BOND_QINTUPLET,
             BondOrder::Amide => chfl_bond_order::CHFL_BOND_AMIDE,
             BondOrder::Aromatic => chfl_bond_order::CHFL_BOND_AROMATIC,
-            BondOrder::__Nonexhaustive => panic!("invalid BondOrder"),
         }
     }
 }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -731,8 +731,10 @@ impl Topology {
 
     /// Add a residue to this topology.
     ///
-    /// The residue `id` must not already be in the topology, and the residue
-    /// must contain only atoms that are not already in another residue.
+    /// # Errors
+    ///
+    /// This function fails is the residue `id` is not already in the topology,
+    /// or if the residue contains atoms that are already in another residue.
     ///
     /// # Example
     /// ```

--- a/src/trajectory.rs
+++ b/src/trajectory.rs
@@ -66,7 +66,7 @@ impl Trajectory {
     where
         P: AsRef<Path>,
     {
-        let path = path.as_ref().to_str().ok_or(Error::utf8_path_error(path.as_ref()))?;
+        let path = path.as_ref().to_str().ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
 
         let path = strings::to_c(path);
         unsafe {
@@ -103,7 +103,7 @@ impl Trajectory {
         S: Into<&'a str>,
     {
         let filename =
-            filename.as_ref().to_str().ok_or(Error::utf8_path_error(filename.as_ref()))?;
+            filename.as_ref().to_str().ok_or_else(|| Error::utf8_path_error(filename.as_ref()))?;
 
         let filename = strings::to_c(filename);
         let format = strings::to_c(format.into());
@@ -291,7 +291,7 @@ impl Trajectory {
     where
         P: AsRef<Path>,
     {
-        let path = path.as_ref().to_str().ok_or(Error::utf8_path_error(path.as_ref()))?;
+        let path = path.as_ref().to_str().ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
 
         let path = strings::to_c(path);
         unsafe {
@@ -322,7 +322,7 @@ impl Trajectory {
         P: AsRef<Path>,
         S: Into<&'a str>,
     {
-        let path = path.as_ref().to_str().ok_or(Error::utf8_path_error(path.as_ref()))?;
+        let path = path.as_ref().to_str().ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
 
         let format = strings::to_c(format.into());
         let path = strings::to_c(path);


### PR DESCRIPTION
This PR contains two part: first it makes sure clippy is happy with the code, and second it ensure the bindings (`chemfiles-sys/lib.rs`) are generated from the header using https://github.com/chemfiles/bindgen.

@ezavod could you give this a quick look?

I completely understand that you did not use bindgen when updating, since the code is a bit messy and hard to modify, but I think it is worth keeping it working as we update to make sure it does not bitrot too much =)