### PR TITLE
Update to chemfiles 0.10.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,3 +88,19 @@ jobs:
       - name: upload coverage
         if: matrix.os == 'ubuntu-18.04'
         run: bash <(curl -s https://codecov.io/bash) -s target/kcov
+
+  # check that the code still builds from source
+  build-from-source:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+      - name: run tests
+        run: cargo test --all --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chemfiles"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Guillaume Fraux <guillaume.fraux@chimie-paristech.fr>"]
 documentation = "http://chemfiles.org/chemfiles.rs/"
 repository = "https://github.com/chemfiles/chemfiles.rs"
@@ -15,7 +15,7 @@ exclude = ["data/*"]
 name = "chemfiles"
 
 [dependencies]
-chemfiles-sys = {path = "chemfiles-sys", version = "0.10.1"}
+chemfiles-sys = {path = "chemfiles-sys", version = "0.10.2"}
 libc = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ libc = "0.2"
 [dev-dependencies]
 approx = "0.4"
 
+[features]
+# force a build from sources even if there is a matching pre-built version
+# available
+build-from-sources = ["chemfiles-sys/build-from-sources"]
+
 [workspace]
 members = [
     "chemfiles-sys",

--- a/chemfiles-sys-tests/Cargo.toml
+++ b/chemfiles-sys-tests/Cargo.toml
@@ -15,4 +15,4 @@ libc = "0.2"
 chemfiles-sys = {path = "../chemfiles-sys"}
 
 [build-dependencies]
-ctest2 = "0.3"
+ctest2 = "0.4"

--- a/chemfiles-sys/CMakeLists.txt
+++ b/chemfiles-sys/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-set(BUILD_SHARED_LIBS OFF)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-add_subdirectory(chemfiles)
+project(chemfiles-rust CXX)
 
 # Get default C++ libraries to link
 file(WRITE ${PROJECT_BINARY_DIR}/cxx_link_libs.cmake "")
@@ -15,3 +13,55 @@ file(WRITE ${PROJECT_BINARY_DIR}/cxx_link_dirs.cmake "")
 foreach(dir ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
     file(APPEND ${PROJECT_BINARY_DIR}/cxx_link_dirs.cmake "${dir}\n")
 endforeach()
+
+set(CHFL_RUST_PREBUILT_TARGET "" CACHE STRING "Pre-built target to download instead of building the code")
+set(CHFL_RUST_PREBUILT_SHA256 "" CACHE STRING "SHA256 sum of the pre-built archive to download")
+
+if (NOT ${CHFL_RUST_PREBUILT_TARGET} STREQUAL "")
+    set(PREBUILT_DOWNLOAD_SUCCESS FALSE)
+    set(PREBUILT_NAME "chemfiles-static.v${CHEMFILES_VERSION}.${CHFL_RUST_PREBUILT_TARGET}.tar.gz")
+    set(PREBUILT_URL "https://github.com/chemfiles/chemfiles-prebuilt/releases/download/v${CHEMFILES_VERSION}/${PREBUILT_NAME}")
+
+    set(PREBUILT_DESINATION ${CMAKE_CURRENT_BINARY_DIR}/${PREBUILT_NAME})
+
+    message(STATUS "trying to download ${PREBUILT_URL}")
+    file(DOWNLOAD
+        ${PREBUILT_URL} ${PREBUILT_DESINATION}
+        STATUS DOWNLOAD_STATUS
+    )
+
+    list(GET DOWNLOAD_STATUS 0 DOWNLOAD_ERROR_CODE)
+    if (DOWNLOAD_ERROR_CODE)
+        file(REMOVE ${PREBUILT_DESINATION})
+        message(STATUS "failed to download prebuilt chemfiles, building from sources")
+    else()
+        set(PREBUILT_DOWNLOAD_SUCCESS TRUE)
+    endif()
+
+    if (PREBUILT_DOWNLOAD_SUCCESS)
+        file(SHA256 ${PREBUILT_DESINATION} PREBUILT_SHA256)
+        if (NOT ${PREBUILT_SHA256} STREQUAL ${CHFL_RUST_PREBUILT_SHA256})
+            message(
+                FATAL_ERROR
+                "corrupted download of prebuilt chemfiles at '${PREBUILT_DESINATION}':\n"
+                "Expected SHA256: ${CHFL_RUST_PREBUILT_SHA256}\n"
+                "Actual SHA256: ${PREBUILT_SHA256}"
+            )
+        endif()
+
+        # this could use file(ARCHIVE_EXTRACT ...), but that's only available
+        # for cmake >= 3.18
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E tar xf ${PREBUILT_DESINATION}
+            WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}
+        )
+
+        install(CODE "message(STATUS \"nothing to install\")")
+        return()
+    endif()
+endif()
+
+# otherwise, try to build from sources
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_subdirectory(chemfiles)

--- a/chemfiles-sys/Cargo.toml
+++ b/chemfiles-sys/Cargo.toml
@@ -14,6 +14,11 @@ path = "lib.rs"
 test = false
 doctest = false
 
+[features]
+# force a build from sources even if there is a matching pre-built version
+# available
+build-from-sources = []
+
 [dependencies]
 libc = "0.2"
 

--- a/chemfiles-sys/Cargo.toml
+++ b/chemfiles-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chemfiles-sys"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Guillaume Fraux <guillaume.fraux@ens.fr>"]
 links = "chemfiles"
 repository = "https://github.com/chemfiles/chemfiles.rs"

--- a/chemfiles-sys/prebuilt.rs
+++ b/chemfiles-sys/prebuilt.rs
@@ -1,0 +1,21 @@
+/// Get the julia triple & sha256 corresponding to the prebuilt libchemfiles
+/// for a given rust triple, if it exists
+pub fn get_prebuilt_info(target: &str) -> Option<(&'static str, &'static str)> {
+    match target {
+        "aarch64-apple-darwin" => Some(("aarch64-apple-darwin", "de8fc3c7534cc9077f91e276524ca53e482a69de966df21965508ba71ee3d21a")),
+        "aarch64-unknown-linux-gnu" => Some(("aarch64-linux-gnu", "8fd043575a198745cfc6993714dc754aa4ce0fae20743f326137b292cb7292fa")),
+        "aarch64-unknown-linux-musl" => Some(("aarch64-linux-musl", "e8d40230bfc8e37910e6766b27f2751598dc2c79d27d93d9b9377625add91e94")),
+        "armv7-unknown-linux-gnueabihf" => Some(("armv7l-linux-gnueabihf", "98ced72ad195129c8045733fd63fe3573910c5fcf2fe0565d9dd445c0b4ee538")),
+        "armv7-unknown-linux-musleabihf" => Some(("armv7l-linux-musleabihf", "2306657577e0c33a8f562ea72579dd4785feea6df9fcfd76e4f104f3804d4a3c")),
+        "i686-unknown-linux-gnu" => Some(("i686-linux-gnu", "297ab506dbdac6dd6febedf544c276475988cff0273b455c5cd9cba7e23805f2")),
+        "i686-unknown-linux-musl" => Some(("i686-linux-musl", "ef29187fed702472178186acfb0e6fddedbc1cd5511cf50b0e976509c0582cad")),
+        "i686-pc-windows-gnu" => Some(("i686-w64-mingw32", "a206dc9ce00b998c8996a7fcf4d3de3ac6d487af950dd9d53fb9009c12b7e860")),
+        "powerpc64le-unknown-linux-gnu" => Some(("powerpc64le-linux-gnu", "7b87fc0c303652ad28101cd0d75ebd03a44cd303918da855c2f40cebac313208")),
+        "x86_64-apple-darwin" => Some(("x86_64-apple-darwin", "6490efd0fef41c4014a48406fe89d30c464bb9857194bc6cf6012fa807acfa71")),
+        "x86_64-unknown-linux-gnu" => Some(("x86_64-linux-gnu", "16cf6f38f817e555d0393db2726ab80b3b6ff1b2d8f884478f938eda9a452371")),
+        "x86_64-unknown-linux-musl" => Some(("x86_64-linux-musl", "8d0ebba7b42cb7bcc123a0ffd118a73046eea19f47f298d790f9dbd88937b4f1")),
+        "x86_64-unknown-freebsd" => Some(("x86_64-unknown-freebsd", "4d2ecca4109198f37c416bf3f5d85cf6d21bd5d3fb1d08c2b0559405d951bfcc")),
+        "x86_64-pc-windows-gnu" => Some(("x86_64-w64-mingw32", "f622c55ff6b20b0c3e2433f2f28dff8b81e863785a1c295f25066b0953eb08fe")),
+        _ => None,
+    }
+}

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -419,7 +419,7 @@ impl UnitCell {
     /// ```
     pub fn wrap(&self, vector: &mut [f64; 3]) {
         unsafe {
-            check_success(chfl_cell_wrap(self.as_ptr(), vector.as_mut_ptr()))
+            check_success(chfl_cell_wrap(self.as_ptr(), vector.as_mut_ptr()));
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -154,11 +154,11 @@ pub fn set_warning_callback<F>(callback: F) where F: WarningCallback + 'static {
     let callback = Box::into_raw(Box::new(callback));
     unsafe {
         if let Some(previous) = LOGGING_CALLBACK {
-            // set the LOGGING_CALLBACK to the new one
-            LOGGING_CALLBACK = Some(callback);
             // drop the previous callback
             let previous = Box::from_raw(previous);
             std::mem::drop(previous);
+            // set the LOGGING_CALLBACK to the new one
+            LOGGING_CALLBACK = Some(callback);
         } else {
             // set the LOGGING_CALLBACK
             LOGGING_CALLBACK = Some(callback);

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -289,7 +289,7 @@ impl Selection {
     /// ```
     pub fn list(&mut self, frame: &Frame) -> Vec<usize> {
         if self.size() != 1 {
-            panic!("can not call `Selection::list` on a multiple selection")
+            panic!("can not call `Selection::list` on a multiple selection");
         }
         return self.evaluate(frame)
             .into_iter()
@@ -405,7 +405,7 @@ mod tests {
         let mut selection = Selection::new("angles: all").unwrap();
         let res = selection.evaluate(&frame);
         for m in &[Match::new(&[0, 1, 2]), Match::new(&[1, 2, 3])] {
-            assert!(res.iter().any(|r| r == m))
+            assert!(res.iter().any(|r| r == m));
         }
     }
 


### PR DESCRIPTION
One big change is that chemfiles-sys now tries to download a pre-built version of chemfiles from github, falling back to build from source if it fails.