### PR TITLE
Introduce an read-only iterator for Frame

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1213,11 +1213,7 @@ mod test {
         assert_eq!(items[0].0.name(), "H1");
         assert_eq!(items[2].0.name(), "H3");
 
-        assert_eq!(items[1].1[0], 0.0);
-        assert_eq!(items[1].1[1], 1.0);
-        assert_eq!(items[1].1[2], 0.0);
-        assert_eq!(items[3].1[0], 1.0);
-        assert_eq!(items[3].1[1], 1.0);
-        assert_eq!(items[3].1[2], 1.0);
+        assert_eq!(items[1].1, [0.0, 1.0, 0.0]);
+        assert_eq!(items[3].1, [1.0, 1.0, 1.0]);
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -937,8 +937,9 @@ impl<'a> Iterator for FrameAtomIterator<'a> {
         if self.frame.size() <= self.index {
             return None;
         }
+        let atom = self.frame.atom(self.index);
         self.index += 1;
-        Some(self.frame.atom(self.index - 1))
+        Some(atom)
     }
 }
 


### PR DESCRIPTION
With this patch, a read-only iterator is implemented to allow such
functionality:

    let frame = Frame::new();

    // Initialize the frame

    for item in &frame {
        let atom: AtomRef = item.0;
        let position: &[f64; 3] = item.1;
        // Consume the values
    }