### PR TITLE
Accept AsRef<Path> when appropriate

### DIFF
--- a/chemfiles-sys-tests/build.rs
+++ b/chemfiles-sys-tests/build.rs
@@ -5,9 +5,7 @@ fn main() {
     cfg.header("chemfiles.h");
     cfg.include("../chemfiles-sys/chemfiles/include");
     cfg.include(".");
-    cfg.type_name(|ty, _is_struct, _is_union| {
-        ty.to_string()
-    });
+    cfg.type_name(|ty, _is_struct, _is_union| ty.to_string());
 
     cfg.skip_roundtrip(|s| s == "chfl_vector3d" || s == "c_bool" || s == "chfl_warning_callback");
 

--- a/chemfiles-sys-tests/main.rs
+++ b/chemfiles-sys-tests/main.rs
@@ -3,8 +3,8 @@
 extern crate chemfiles_sys;
 extern crate libc;
 
-use libc::*;
 use chemfiles_sys::*;
+use libc::*;
 
 #[allow(warnings)]
 include!(concat!(env!("OUT_DIR"), "/ctest.rs"));

--- a/chemfiles-sys/build.rs
+++ b/chemfiles-sys/build.rs
@@ -2,9 +2,11 @@
 
 extern crate cmake;
 
-use std::io::prelude::*;
-use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::{
+    fs::File,
+    io::prelude::*,
+    path::{Path, PathBuf},
+};
 
 fn main() {
     let out_dir = build_chemfiles();
@@ -20,7 +22,10 @@ fn build_chemfiles() -> PathBuf {
     }
 
     let mut cmake = cmake::Config::new(".");
-    cmake.define("CHEMFILES_VERSION", std::env::var("CARGO_PKG_VERSION").expect("cargo should set CARGO_PKG_VERSION"));
+    cmake.define(
+        "CHEMFILES_VERSION",
+        std::env::var("CARGO_PKG_VERSION").expect("cargo should set CARGO_PKG_VERSION"),
+    );
 
     let target = std::env::var("TARGET").expect("cargo should set TARGET");
     if !cfg!(feature = "build-from-sources") {

--- a/chemfiles-sys/prebuilt.rs
+++ b/chemfiles-sys/prebuilt.rs
@@ -2,20 +2,62 @@
 /// for a given rust triple, if it exists
 pub fn get_prebuilt_info(target: &str) -> Option<(&'static str, &'static str)> {
     match target {
-        "aarch64-apple-darwin" => Some(("aarch64-apple-darwin", "d363921687c3d9a292a680567f3244cd1159f2c17a4b897361d7703a954b3d31")),
-        "aarch64-unknown-linux-gnu" => Some(("aarch64-linux-gnu", "503b5a384cbc627d6dfa0e3c38923fd4b881619aa2c58d8d37257fb00d593b73")),
-        "aarch64-unknown-linux-musl" => Some(("aarch64-linux-musl", "26da29259916f1b57c567a7e4ad72fa113065d69b2c131a0de92ed77bdc1c943")),
-        "armv7-unknown-linux-gnueabihf" => Some(("armv7l-linux-gnueabihf", "14e950a8e10c2e1e3408c9fbfee0da463a978f3c139fc9ddb6f79323c7eab48d")),
-        "armv7-unknown-linux-musleabihf" => Some(("armv7l-linux-musleabihf", "444d30b2c82c1ba9f9be2c0ba5092b3d86bfbb02f995935490ab12bea0767423")),
-        "i686-unknown-linux-gnu" => Some(("i686-linux-gnu", "d4d4833269b7589e8035b5718236c40477969c3c281b20cdb3a9f09eeb291396")),
-        "i686-unknown-linux-musl" => Some(("i686-linux-musl", "b8914c51fe06fd1848ceaf0b5666e05ff4b1dd3edb05dea26b9bbc99d51426e3")),
-        "i686-pc-windows-gnu" => Some(("i686-w64-mingw32", "f4cae7e8fcca7d32e539f9c080dfd950cf5b835ffa3d75aae7dd16f597829573")),
-        "powerpc64le-unknown-linux-gnu" => Some(("powerpc64le-linux-gnu", "af7adf574ddc953593dda2e89b39d71c6674e44cd8a3fc729edc1f48b9f01542")),
-        "x86_64-apple-darwin" => Some(("x86_64-apple-darwin", "0783cb15705576f4b5af6bed583540a256a83a906d160dc6f157b7d5f594579b")),
-        "x86_64-unknown-linux-gnu" => Some(("x86_64-linux-gnu", "0a2a839885effae7df0c279ad024b6fa7cb73666c2c2fe9b6675cebc614b088e")),
-        "x86_64-unknown-linux-musl" => Some(("x86_64-linux-musl", "866edb9fb201e05b24c04d115ba9cb27e5381f94bf5637c7409e43b4513ba4a4")),
-        "x86_64-unknown-freebsd" => Some(("x86_64-unknown-freebsd", "51f659041fb65f43038541dabb2dfa47712bb0ec08ea57065954e42334d9f797")),
-        "x86_64-pc-windows-gnu" => Some(("x86_64-w64-mingw32", "e183dfbef91e5ce608be7ae8c3ca902982ab0f5b7276d4049958cbc75c0155c6")),
+        "aarch64-apple-darwin" => Some((
+            "aarch64-apple-darwin",
+            "d363921687c3d9a292a680567f3244cd1159f2c17a4b897361d7703a954b3d31",
+        )),
+        "aarch64-unknown-linux-gnu" => Some((
+            "aarch64-linux-gnu",
+            "503b5a384cbc627d6dfa0e3c38923fd4b881619aa2c58d8d37257fb00d593b73",
+        )),
+        "aarch64-unknown-linux-musl" => Some((
+            "aarch64-linux-musl",
+            "26da29259916f1b57c567a7e4ad72fa113065d69b2c131a0de92ed77bdc1c943",
+        )),
+        "armv7-unknown-linux-gnueabihf" => Some((
+            "armv7l-linux-gnueabihf",
+            "14e950a8e10c2e1e3408c9fbfee0da463a978f3c139fc9ddb6f79323c7eab48d",
+        )),
+        "armv7-unknown-linux-musleabihf" => Some((
+            "armv7l-linux-musleabihf",
+            "444d30b2c82c1ba9f9be2c0ba5092b3d86bfbb02f995935490ab12bea0767423",
+        )),
+        "i686-unknown-linux-gnu" => Some((
+            "i686-linux-gnu",
+            "d4d4833269b7589e8035b5718236c40477969c3c281b20cdb3a9f09eeb291396",
+        )),
+        "i686-unknown-linux-musl" => Some((
+            "i686-linux-musl",
+            "b8914c51fe06fd1848ceaf0b5666e05ff4b1dd3edb05dea26b9bbc99d51426e3",
+        )),
+        "i686-pc-windows-gnu" => Some((
+            "i686-w64-mingw32",
+            "f4cae7e8fcca7d32e539f9c080dfd950cf5b835ffa3d75aae7dd16f597829573",
+        )),
+        "powerpc64le-unknown-linux-gnu" => Some((
+            "powerpc64le-linux-gnu",
+            "af7adf574ddc953593dda2e89b39d71c6674e44cd8a3fc729edc1f48b9f01542",
+        )),
+        "x86_64-apple-darwin" => Some((
+            "x86_64-apple-darwin",
+            "0783cb15705576f4b5af6bed583540a256a83a906d160dc6f157b7d5f594579b",
+        )),
+        "x86_64-unknown-linux-gnu" => Some((
+            "x86_64-linux-gnu",
+            "0a2a839885effae7df0c279ad024b6fa7cb73666c2c2fe9b6675cebc614b088e",
+        )),
+        "x86_64-unknown-linux-musl" => Some((
+            "x86_64-linux-musl",
+            "866edb9fb201e05b24c04d115ba9cb27e5381f94bf5637c7409e43b4513ba4a4",
+        )),
+        "x86_64-unknown-freebsd" => Some((
+            "x86_64-unknown-freebsd",
+            "51f659041fb65f43038541dabb2dfa47712bb0ec08ea57065954e42334d9f797",
+        )),
+        "x86_64-pc-windows-gnu" => Some((
+            "x86_64-w64-mingw32",
+            "e183dfbef91e5ce608be7ae8c3ca902982ab0f5b7276d4049958cbc75c0155c6",
+        )),
         _ => None,
     }
 }

--- a/examples/indexes.rs
+++ b/examples/indexes.rs
@@ -18,6 +18,6 @@ fn main() {
 
     println!("Atoms with x < 5: ");
     for i in less_than_five {
-        println!("  - {}", i);
+        println!("  - {i}");
     }
 }

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -104,7 +104,7 @@ impl Atom {
 
     /// Get the underlying C pointer as a const pointer.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *const CHFL_ATOM {
+    pub(crate) const fn as_ptr(&self) -> *const CHFL_ATOM {
         self.handle
     }
 

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -59,10 +59,10 @@ impl<'a> DerefMut for AtomMut<'a> {
 }
 
 impl Clone for Atom {
-    fn clone(&self) -> Atom {
+    fn clone(&self) -> Self {
         unsafe {
             let new_handle = chfl_atom_copy(self.as_ptr());
-            Atom::from_ptr(new_handle)
+            Self::from_ptr(new_handle)
         }
     }
 }
@@ -73,9 +73,9 @@ impl Atom {
     /// This function is unsafe because no validity check is made on the
     /// pointer.
     #[inline]
-    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_ATOM) -> Atom {
+    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_ATOM) -> Self {
         check_not_null(ptr);
-        Atom { handle: ptr }
+        Self { handle: ptr }
     }
 
     /// Create a borrowed `Atom` from a C pointer.
@@ -85,7 +85,7 @@ impl Atom {
     #[inline]
     pub(crate) unsafe fn ref_from_ptr<'a>(ptr: *const CHFL_ATOM) -> AtomRef<'a> {
         AtomRef {
-            inner: Atom::from_ptr(ptr as *mut CHFL_ATOM),
+            inner: Self::from_ptr(ptr as *mut CHFL_ATOM),
             marker: PhantomData,
         }
     }
@@ -97,7 +97,7 @@ impl Atom {
     #[inline]
     pub(crate) unsafe fn ref_mut_from_ptr<'a>(ptr: *mut CHFL_ATOM) -> AtomMut<'a> {
         AtomMut {
-            inner: Atom::from_ptr(ptr),
+            inner: Self::from_ptr(ptr),
             marker: PhantomData,
         }
     }
@@ -122,11 +122,11 @@ impl Atom {
     /// let atom = Atom::new("He");
     /// assert_eq!(atom.name(), "He");
     /// ```
-    pub fn new<'a>(name: impl Into<&'a str>) -> Atom {
+    pub fn new<'a>(name: impl Into<&'a str>) -> Self {
         let buffer = strings::to_c(name.into());
         unsafe {
             let handle = chfl_atom(buffer.as_ptr());
-            Atom::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,11 +1,13 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
-use std::ops::{Drop, Deref, DerefMut};
-use std::marker::PhantomData;
-use std::ptr;
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut, Drop},
+    ptr,
+};
 
 use chemfiles_sys::*;
-use errors::{check_success, check_not_null, check, Error};
+use errors::{check, check_not_null, check_success, Error};
 
 /// Available unit cell shapes.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -60,7 +62,7 @@ pub struct UnitCell {
 /// An analog to a reference to an unit cell (`&UnitCell`)
 pub struct UnitCellRef<'a> {
     inner: UnitCell,
-    marker: PhantomData<&'a UnitCell>
+    marker: PhantomData<&'a UnitCell>,
 }
 
 impl<'a> Deref for UnitCellRef<'a> {
@@ -73,7 +75,7 @@ impl<'a> Deref for UnitCellRef<'a> {
 /// An analog to a mutable reference to an unit cell (`&mut UnitCell`)
 pub struct UnitCellMut<'a> {
     inner: UnitCell,
-    marker: PhantomData<&'a mut UnitCell>
+    marker: PhantomData<&'a mut UnitCell>,
 }
 
 impl<'a> Deref for UnitCellMut<'a> {
@@ -105,9 +107,7 @@ impl UnitCell {
     #[inline]
     pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_CELL) -> UnitCell {
         check_not_null(ptr);
-        UnitCell {
-            handle: ptr
-        }
+        UnitCell { handle: ptr }
     }
 
     /// Create a borrowed `UnitCell` from a C pointer.
@@ -178,7 +178,8 @@ impl UnitCell {
     /// ```
     pub fn infinite() -> UnitCell {
         let mut cell = UnitCell::new([0.0, 0.0, 0.0]);
-        cell.set_shape(CellShape::Infinite).expect("could not set cell shape");
+        cell.set_shape(CellShape::Infinite)
+            .expect("could not set cell shape");
         return cell;
     }
 
@@ -268,9 +269,7 @@ impl UnitCell {
     /// assert!(UnitCell::infinite().set_lengths([1.0, 1.0, 1.0]).is_err());
     /// ```
     pub fn set_lengths(&mut self, lengths: [f64; 3]) -> Result<(), Error> {
-        unsafe {
-            check(chfl_cell_set_lengths(self.as_mut_ptr(), lengths.as_ptr()))
-        }
+        unsafe { check(chfl_cell_set_lengths(self.as_mut_ptr(), lengths.as_ptr())) }
     }
 
     /// Get the three angles of the cell, in degrees.
@@ -314,9 +313,7 @@ impl UnitCell {
     /// assert_eq!(cell.angles(), [90.0, 90.0, 90.0]);
     /// ```
     pub fn set_angles(&mut self, angles: [f64; 3]) -> Result<(), Error> {
-        unsafe {
-            check(chfl_cell_set_angles(self.as_mut_ptr(), angles.as_ptr()))
-        }
+        unsafe { check(chfl_cell_set_angles(self.as_mut_ptr(), angles.as_ptr())) }
     }
 
     /// Get the unit cell matricial representation.
@@ -385,9 +382,7 @@ impl UnitCell {
     /// assert_eq!(cell.shape(), CellShape::Triclinic);
     /// ```
     pub fn set_shape(&mut self, shape: CellShape) -> Result<(), Error> {
-        unsafe {
-            check(chfl_cell_set_shape(self.as_mut_ptr(), shape.into()))
-        }
+        unsafe { check(chfl_cell_set_shape(self.as_mut_ptr(), shape.into())) }
     }
 
     /// Get the volume of the unit cell.
@@ -431,7 +426,6 @@ impl Drop for UnitCell {
         }
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -515,11 +509,7 @@ mod test {
 
         assert_eq!(cell.shape(), CellShape::Triclinic);
         for i in 0..3 {
-            assert_ulps_eq!(
-                cell.lengths()[i],
-                [123.0, 234.0, 345.0][i],
-                epsilon = 1e-3
-            );
+            assert_ulps_eq!(cell.lengths()[i], [123.0, 234.0, 345.0][i], epsilon = 1e-3);
             assert_ulps_eq!(cell.angles()[i], [67.0, 78.0, 89.0][i], epsilon = 1e-3);
         }
 

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -21,21 +21,21 @@ pub enum CellShape {
 }
 
 impl From<chfl_cellshape> for CellShape {
-    fn from(celltype: chfl_cellshape) -> CellShape {
+    fn from(celltype: chfl_cellshape) -> Self {
         match celltype {
-            chfl_cellshape::CHFL_CELL_ORTHORHOMBIC => CellShape::Orthorhombic,
-            chfl_cellshape::CHFL_CELL_TRICLINIC => CellShape::Triclinic,
-            chfl_cellshape::CHFL_CELL_INFINITE => CellShape::Infinite,
+            chfl_cellshape::CHFL_CELL_ORTHORHOMBIC => Self::Orthorhombic,
+            chfl_cellshape::CHFL_CELL_TRICLINIC => Self::Triclinic,
+            chfl_cellshape::CHFL_CELL_INFINITE => Self::Infinite,
         }
     }
 }
 
 impl From<CellShape> for chfl_cellshape {
-    fn from(celltype: CellShape) -> chfl_cellshape {
+    fn from(celltype: CellShape) -> Self {
         match celltype {
-            CellShape::Orthorhombic => chfl_cellshape::CHFL_CELL_ORTHORHOMBIC,
-            CellShape::Triclinic => chfl_cellshape::CHFL_CELL_TRICLINIC,
-            CellShape::Infinite => chfl_cellshape::CHFL_CELL_INFINITE,
+            CellShape::Orthorhombic => Self::CHFL_CELL_ORTHORHOMBIC,
+            CellShape::Triclinic => Self::CHFL_CELL_TRICLINIC,
+            CellShape::Infinite => Self::CHFL_CELL_INFINITE,
         }
     }
 }
@@ -92,10 +92,10 @@ impl<'a> DerefMut for UnitCellMut<'a> {
 }
 
 impl Clone for UnitCell {
-    fn clone(&self) -> UnitCell {
+    fn clone(&self) -> Self {
         unsafe {
             let new_handle = chfl_cell_copy(self.as_ptr());
-            UnitCell::from_ptr(new_handle)
+            Self::from_ptr(new_handle)
         }
     }
 }
@@ -105,9 +105,9 @@ impl UnitCell {
     ///
     /// This function is unsafe because no validity check is made on the pointer.
     #[inline]
-    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_CELL) -> UnitCell {
+    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_CELL) -> Self {
         check_not_null(ptr);
-        UnitCell { handle: ptr }
+        Self { handle: ptr }
     }
 
     /// Create a borrowed `UnitCell` from a C pointer.
@@ -117,7 +117,7 @@ impl UnitCell {
     #[inline]
     pub(crate) unsafe fn ref_from_ptr<'a>(ptr: *const CHFL_CELL) -> UnitCellRef<'a> {
         UnitCellRef {
-            inner: UnitCell::from_ptr(ptr as *mut CHFL_CELL),
+            inner: Self::from_ptr(ptr as *mut CHFL_CELL),
             marker: PhantomData,
         }
     }
@@ -130,7 +130,7 @@ impl UnitCell {
     #[inline]
     pub(crate) unsafe fn ref_mut_from_ptr<'a>(ptr: *mut CHFL_CELL) -> UnitCellMut<'a> {
         UnitCellMut {
-            inner: UnitCell::from_ptr(ptr),
+            inner: Self::from_ptr(ptr),
             marker: PhantomData,
         }
     }
@@ -158,10 +158,10 @@ impl UnitCell {
     /// assert_eq!(cell.angles(), [90.0, 90.0, 90.0]);
     /// assert_eq!(cell.shape(), CellShape::Orthorhombic);
     /// ```
-    pub fn new(lengths: [f64; 3]) -> UnitCell {
+    pub fn new(lengths: [f64; 3]) -> Self {
         unsafe {
             let handle = chfl_cell(lengths.as_ptr(), ptr::null());
-            UnitCell::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 
@@ -176,8 +176,8 @@ impl UnitCell {
     /// assert_eq!(cell.angles(), [90.0, 90.0, 90.0]);
     /// assert_eq!(cell.shape(), CellShape::Infinite);
     /// ```
-    pub fn infinite() -> UnitCell {
-        let mut cell = UnitCell::new([0.0, 0.0, 0.0]);
+    pub fn infinite() -> Self {
+        let mut cell = Self::new([0.0, 0.0, 0.0]);
         cell.set_shape(CellShape::Infinite)
             .expect("could not set cell shape");
         return cell;
@@ -200,10 +200,10 @@ impl UnitCell {
     /// assert_eq!(cell.angles()[2], 90.0);
     /// assert_eq!(cell.shape(), CellShape::Triclinic);
     /// ```
-    pub fn triclinic(lengths: [f64; 3], angles: [f64; 3]) -> UnitCell {
+    pub fn triclinic(lengths: [f64; 3], angles: [f64; 3]) -> Self {
         unsafe {
             let handle = chfl_cell(lengths.as_ptr(), angles.as_ptr());
-            UnitCell::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 
@@ -228,10 +228,10 @@ impl UnitCell {
     /// assert_eq!(cell.angles(), [90.0, 90.0, 90.0]);
     /// assert_eq!(cell.shape(), CellShape::Orthorhombic);
     /// ```
-    pub fn from_matrix(mut matrix: [[f64; 3]; 3]) -> UnitCell {
+    pub fn from_matrix(mut matrix: [[f64; 3]; 3]) -> Self {
         unsafe {
             let handle = chfl_cell_from_matrix(matrix.as_mut_ptr());
-            UnitCell::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -137,7 +137,7 @@ impl UnitCell {
 
     /// Get the underlying C pointer as a const pointer.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *const CHFL_CELL {
+    pub(crate) const fn as_ptr(&self) -> *const CHFL_CELL {
         self.handle
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,15 +2,16 @@
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
 extern crate libc;
 
-use std::error;
-use std::fmt;
-use std::panic::{self, RefUnwindSafe};
-use std::path::Path;
-
-use self::libc::c_char;
+use std::{
+    error, fmt,
+    panic::{self, RefUnwindSafe},
+    path::Path,
+};
 
 use chemfiles_sys::*;
 use strings;
+
+use self::libc::c_char;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Error type for Chemfiles.
@@ -67,10 +68,7 @@ impl From<chfl_status> for Error {
         };
 
         let message = Error::last_error();
-        Error {
-            status,
-            message,
-        }
+        Error { status, message }
     }
 }
 
@@ -116,20 +114,24 @@ pub(crate) fn check(status: chfl_status) -> Result<(), Error> {
 
 /// Check return value of a C function, panic if it failed.
 pub(crate) fn check_success(status: chfl_status) {
-    assert!(status == chfl_status::CHFL_SUCCESS, "unexpected failure: {}", Error::last_error());
+    assert!(
+        status == chfl_status::CHFL_SUCCESS,
+        "unexpected failure: {}",
+        Error::last_error()
+    );
 }
 
 /// Check a pointer for null.
 pub(crate) fn check_not_null<T>(ptr: *const T) {
-    assert!(!ptr.is_null(), "unexpected null pointer: {}", Error::last_error());
+    assert!(
+        !ptr.is_null(),
+        "unexpected null pointer: {}",
+        Error::last_error()
+    );
 }
 
 pub trait WarningCallback: RefUnwindSafe + Fn(&str) {}
-impl<T> WarningCallback for T
-where
-    T: RefUnwindSafe + Fn(&str),
-{
-}
+impl<T> WarningCallback for T where T: RefUnwindSafe + Fn(&str) {}
 
 static mut LOGGING_CALLBACK: Option<*mut dyn WarningCallback<Output = ()>> = None;
 
@@ -145,7 +147,10 @@ extern "C" fn warning_callback(message: *const c_char) {
 
 /// Use `callback` for every chemfiles warning. The callback will be passed
 /// the warning message. This will drop any previous warning callback.
-pub fn set_warning_callback<F>(callback: F) where F: WarningCallback + 'static {
+pub fn set_warning_callback<F>(callback: F)
+where
+    F: WarningCallback + 'static,
+{
     // box callback to ensure it stays accessible
     let callback = Box::into_raw(Box::new(callback));
     unsafe {
@@ -163,7 +168,6 @@ pub fn set_warning_callback<F>(callback: F) where F: WarningCallback + 'static {
         }
     }
 }
-
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -189,11 +193,11 @@ impl error::Error for Error {
     }
 }
 
-
 #[cfg(test)]
 mod test {
-    use super::*;
     use Trajectory;
+
+    use super::*;
 
     #[test]
     fn errors() {
@@ -210,14 +214,41 @@ mod test {
 
     #[test]
     fn codes() {
-        assert_eq!(Error::from(chfl_status::CHFL_SUCCESS).status, Status::Success);
-        assert_eq!(Error::from(chfl_status::CHFL_CXX_ERROR).status, Status::StdCppError);
-        assert_eq!(Error::from(chfl_status::CHFL_GENERIC_ERROR).status, Status::ChemfilesError);
-        assert_eq!(Error::from(chfl_status::CHFL_MEMORY_ERROR).status, Status::MemoryError);
-        assert_eq!(Error::from(chfl_status::CHFL_FILE_ERROR).status, Status::FileError);
-        assert_eq!(Error::from(chfl_status::CHFL_FORMAT_ERROR).status, Status::FormatError);
-        assert_eq!(Error::from(chfl_status::CHFL_SELECTION_ERROR).status, Status::SelectionError);
-        assert_eq!(Error::from(chfl_status::CHFL_OUT_OF_BOUNDS).status, Status::OutOfBounds);
-        assert_eq!(Error::from(chfl_status::CHFL_PROPERTY_ERROR).status, Status::PropertyError);
+        assert_eq!(
+            Error::from(chfl_status::CHFL_SUCCESS).status,
+            Status::Success
+        );
+        assert_eq!(
+            Error::from(chfl_status::CHFL_CXX_ERROR).status,
+            Status::StdCppError
+        );
+        assert_eq!(
+            Error::from(chfl_status::CHFL_GENERIC_ERROR).status,
+            Status::ChemfilesError
+        );
+        assert_eq!(
+            Error::from(chfl_status::CHFL_MEMORY_ERROR).status,
+            Status::MemoryError
+        );
+        assert_eq!(
+            Error::from(chfl_status::CHFL_FILE_ERROR).status,
+            Status::FileError
+        );
+        assert_eq!(
+            Error::from(chfl_status::CHFL_FORMAT_ERROR).status,
+            Status::FormatError
+        );
+        assert_eq!(
+            Error::from(chfl_status::CHFL_SELECTION_ERROR).status,
+            Status::SelectionError
+        );
+        assert_eq!(
+            Error::from(chfl_status::CHFL_OUT_OF_BOUNDS).status,
+            Status::OutOfBounds
+        );
+        assert_eq!(
+            Error::from(chfl_status::CHFL_PROPERTY_ERROR).status,
+            Status::PropertyError
+        );
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,7 +53,7 @@ pub enum Status {
 }
 
 impl From<chfl_status> for Error {
-    fn from(status: chfl_status) -> Error {
+    fn from(status: chfl_status) -> Self {
         let status = match status {
             chfl_status::CHFL_SUCCESS => Status::Success,
             chfl_status::CHFL_CXX_ERROR => Status::StdCppError,
@@ -67,14 +67,14 @@ impl From<chfl_status> for Error {
             chfl_status::CHFL_PROPERTY_ERROR => Status::PropertyError,
         };
 
-        let message = Error::last_error();
-        Error { status, message }
+        let message = Self::last_error();
+        Self { status, message }
     }
 }
 
 impl From<std::str::Utf8Error> for Error {
     fn from(_: std::str::Utf8Error) -> Self {
-        Error {
+        Self {
             status: Status::UTF8PathError,
             message: "failed to convert data to UTF8 string".into(),
         }
@@ -83,8 +83,8 @@ impl From<std::str::Utf8Error> for Error {
 
 impl Error {
     /// Create a new error because the given `path` is invalid UTF-8 data
-    pub(crate) fn utf8_path_error(path: &Path) -> Error {
-        Error {
+    pub(crate) fn utf8_path_error(path: &Path) -> Self {
+        Self {
             status: Status::UTF8PathError,
             message: format!("Could not convert '{}' to UTF8", path.display()),
         }
@@ -104,7 +104,7 @@ impl Error {
 }
 
 /// Check return value of a C function, and get the error if needed.
-pub(crate) fn check(status: chfl_status) -> Result<(), Error> {
+pub fn check(status: chfl_status) -> Result<(), Error> {
     if status == chfl_status::CHFL_SUCCESS {
         Ok(())
     } else {
@@ -113,7 +113,7 @@ pub(crate) fn check(status: chfl_status) -> Result<(), Error> {
 }
 
 /// Check return value of a C function, panic if it failed.
-pub(crate) fn check_success(status: chfl_status) {
+pub fn check_success(status: chfl_status) {
     assert!(
         status == chfl_status::CHFL_SUCCESS,
         "unexpected failure: {}",
@@ -122,7 +122,7 @@ pub(crate) fn check_success(status: chfl_status) {
 }
 
 /// Check a pointer for null.
-pub(crate) fn check_not_null<T>(ptr: *const T) {
+pub fn check_not_null<T>(ptr: *const T) {
     assert!(
         !ptr.is_null(),
         "unexpected null pointer: {}",

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -185,10 +185,9 @@ impl Frame {
         velocity: impl Into<Option<[f64; 3]>>,
     ) {
         let velocity = velocity.into();
-        let velocity_ptr = match velocity {
-            Some(ref data) => data.as_ptr(),
-            None => ptr::null(),
-        };
+        let velocity_ptr = velocity
+            .as_ref()
+            .map_or_else(ptr::null, |data| data.as_ptr());
 
         unsafe {
             check_success(chfl_frame_add_atom(

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,16 +1,16 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
-use std::ops::Drop;
-use std::ptr;
-use std::slice;
+use std::{ops::Drop, ptr, slice};
 
-use super::{Atom, AtomMut, AtomRef};
-use super::{BondOrder, Residue, Topology, TopologyRef};
-use super::{UnitCell, UnitCellMut, UnitCellRef};
 use chemfiles_sys::*;
 use errors::{check, check_not_null, check_success, Error};
 use property::{PropertiesIter, Property, RawProperty};
 use strings;
+
+use super::{
+    Atom, AtomMut, AtomRef, BondOrder, Residue, Topology, TopologyRef, UnitCell, UnitCellMut,
+    UnitCellRef,
+};
 
 /// A `Frame` contains data from one simulation step: the current unit
 /// cell, the topology, the positions, and the velocities of the particles in
@@ -953,8 +953,11 @@ impl<'a> Iterator for AtomIter<'a> {
 
 #[cfg(test)]
 mod test {
+    use Atom;
+    use Topology;
+    use UnitCell;
+
     use super::*;
-    use {Atom, Topology, UnitCell};
 
     #[test]
     fn clone() {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -48,7 +48,7 @@ impl Frame {
 
     /// Get the underlying C pointer as a const pointer.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *const CHFL_FRAME {
+    pub(crate) const fn as_ptr(&self) -> *const CHFL_FRAME {
         self.handle
     }
 
@@ -65,7 +65,7 @@ impl Frame {
     /// mutable borrows
     #[inline]
     #[allow(non_snake_case)]
-    pub(crate) fn as_mut_ptr_MANUALLY_CHECKING_BORROW(&self) -> *mut CHFL_FRAME {
+    pub(crate) const fn as_mut_ptr_MANUALLY_CHECKING_BORROW(&self) -> *mut CHFL_FRAME {
         self.handle
     }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -21,10 +21,10 @@ pub struct Frame {
 }
 
 impl Clone for Frame {
-    fn clone(&self) -> Frame {
+    fn clone(&self) -> Self {
         unsafe {
             let new_handle = chfl_frame_copy(self.as_ptr());
-            Frame::from_ptr(new_handle)
+            Self::from_ptr(new_handle)
         }
     }
 }
@@ -41,9 +41,9 @@ impl Frame {
     /// This function is unsafe because no validity check is made on the pointer,
     /// except for it being non-null.
     #[inline]
-    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_FRAME) -> Frame {
+    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_FRAME) -> Self {
         check_not_null(ptr);
-        Frame { handle: ptr }
+        Self { handle: ptr }
     }
 
     /// Get the underlying C pointer as a const pointer.
@@ -78,8 +78,8 @@ impl Frame {
     ///
     /// assert_eq!(frame.size(), 0);
     /// ```
-    pub fn new() -> Frame {
-        unsafe { Frame::from_ptr(chfl_frame()) }
+    pub fn new() -> Self {
+        unsafe { Self::from_ptr(chfl_frame()) }
     }
 
     /// Get a reference to the atom at the given `index` in this frame.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,15 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::needless_return, clippy::module_name_repetitions)]
 #![allow(clippy::must_use_candidate, clippy::wildcard_imports)]
-
 // Allow a few more clippy lints in test mode
-#![cfg_attr(test, allow(clippy::float_cmp, clippy::unreadable_literal, clippy::shadow_unrelated))]
-
+#![cfg_attr(
+    test,
+    allow(
+        clippy::float_cmp,
+        clippy::unreadable_literal,
+        clippy::shadow_unrelated
+    )
+)]
 // deny(warnings) in doc tests
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(unused_variables))))]
@@ -46,28 +51,19 @@ use chemfiles_sys::{chfl_add_configuration, chfl_version};
 mod strings;
 
 mod errors;
-pub use errors::{Error, Status};
-pub use errors::set_warning_callback;
+pub use errors::{set_warning_callback, Error, Status};
 
 mod atom;
-pub use atom::Atom;
-pub use atom::AtomRef;
-pub use atom::AtomMut;
+pub use atom::{Atom, AtomMut, AtomRef};
 
 mod cell;
-pub use cell::UnitCell;
-pub use cell::UnitCellRef;
-pub use cell::UnitCellMut;
-pub use cell::CellShape;
+pub use cell::{CellShape, UnitCell, UnitCellMut, UnitCellRef};
 
 mod residue;
-pub use residue::Residue;
-pub use residue::ResidueRef;
+pub use residue::{Residue, ResidueRef};
 
 mod topology;
-pub use topology::Topology;
-pub use topology::TopologyRef;
-pub use topology::BondOrder;
+pub use topology::{BondOrder, Topology, TopologyRef};
 
 mod frame;
 pub use frame::Frame;
@@ -79,11 +75,10 @@ mod selection;
 pub use selection::{Match, Selection};
 
 mod property;
-pub use property::Property;
-pub use property::PropertiesIter;
+pub use property::{PropertiesIter, Property};
 
 mod misc;
-pub use misc::{FormatMetadata, formats_list, guess_format};
+pub use misc::{formats_list, guess_format, FormatMetadata};
 
 /// Get the version of the chemfiles library.
 ///
@@ -118,9 +113,7 @@ where
     S: AsRef<str>,
 {
     let buffer = strings::to_c(path.as_ref());
-    unsafe {
-        errors::check(chfl_add_configuration(buffer.as_ptr()))
-    }
+    unsafe { errors::check(chfl_add_configuration(buffer.as_ptr())) }
 }
 
 #[cfg(test)]

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,7 +1,7 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2020 Guillaume Fraux -- BSD licensed
 
-use std::{convert::TryInto, ffi::CStr};
+use std::{convert::TryInto, ffi::CStr, path::Path};
 
 use chemfiles_sys::{chfl_format_metadata, chfl_formats_list, chfl_free, chfl_guess_format};
 use errors::check_success;
@@ -121,6 +121,10 @@ pub fn formats_list() -> Vec<FormatMetadata> {
 ///
 /// This function returns an error if the file format couldn't be guessed.
 ///
+/// # Panics
+///
+/// This function panics if the path can't be converted to a Unicode string.
+///
 /// # Examples
 /// ```
 /// let format = chemfiles::guess_format("trajectory.xyz.xz").unwrap();
@@ -132,7 +136,14 @@ pub fn formats_list() -> Vec<FormatMetadata> {
 /// let format = chemfiles::guess_format("trajectory.unknown.format");
 /// assert!(format.is_err());
 /// ```
-pub fn guess_format(path: &str) -> Result<String, Error> {
+pub fn guess_format<P>(path: P) -> Result<String, Error>
+where
+    P: AsRef<Path>,
+{
+    let path = path
+        .as_ref()
+        .to_str()
+        .expect("couldn't convert path to Unicode");
     let path = crate::strings::to_c(path);
     let mut buffer = vec![0; 128];
     unsafe {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -6,6 +6,8 @@ use std::{convert::TryInto, ffi::CStr};
 use chemfiles_sys::{chfl_format_metadata, chfl_formats_list, chfl_free, chfl_guess_format};
 use errors::check_success;
 
+use crate::{errors::check, Error};
+
 /// `FormatMetadata` contains metadata associated with one format.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -115,23 +117,30 @@ pub fn formats_list() -> Vec<FormatMetadata> {
 /// `Trajectory` constructors, i.e. `"<format name> [/ <compression>]"`, where
 /// compression is optional.
 ///
+/// # Errors
+///
+/// This function returns an error if the file format couldn't be guessed.
+///
 /// # Examples
 /// ```
-/// let format = chemfiles::guess_format("trajectory.xyz.xz");
+/// let format = chemfiles::guess_format("trajectory.xyz.xz").unwrap();
 /// assert_eq!(format, "XYZ / XZ");
 ///
-/// let format = chemfiles::guess_format("trajectory.nc");
+/// let format = chemfiles::guess_format("trajectory.nc").unwrap();
 /// assert_eq!(format, "Amber NetCDF");
+///
+/// let format = chemfiles::guess_format("trajectory.unknown.format");
+/// assert!(format.is_err());
 /// ```
-pub fn guess_format(path: &str) -> String {
+pub fn guess_format(path: &str) -> Result<String, Error> {
     let path = crate::strings::to_c(path);
     let mut buffer = vec![0; 128];
     unsafe {
-        check_success(chfl_guess_format(
+        check(chfl_guess_format(
             path.as_ptr(),
             buffer.as_mut_ptr(),
             buffer.len() as u64,
-        ));
+        ))?;
     }
-    return crate::strings::from_c(buffer.as_ptr());
+    Ok(crate::strings::from_c(buffer.as_ptr()))
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,8 +1,7 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2020 Guillaume Fraux -- BSD licensed
 
-use std::convert::TryInto;
-use std::ffi::CStr;
+use std::{convert::TryInto, ffi::CStr};
 
 use chemfiles_sys::{chfl_format_metadata, chfl_formats_list, chfl_free, chfl_guess_format};
 use errors::check_success;
@@ -89,12 +88,12 @@ pub fn formats_list() -> Vec<FormatMetadata> {
     let mut count: u64 = 0;
     let formats_slice = unsafe {
         check_success(chfl_formats_list(&mut formats, &mut count));
-        std::slice::from_raw_parts(formats, count.try_into().expect("failed to convert u64 to usize"))
+        std::slice::from_raw_parts(
+            formats,
+            count.try_into().expect("failed to convert u64 to usize"),
+        )
     };
-    let formats_vec = formats_slice
-        .iter()
-        .map(FormatMetadata::from_raw)
-        .collect();
+    let formats_vec = formats_slice.iter().map(FormatMetadata::from_raw).collect();
     unsafe {
         let _ = chfl_free(formats as *const _);
     }
@@ -129,7 +128,9 @@ pub fn guess_format(path: &str) -> String {
     let mut buffer = vec![0; 128];
     unsafe {
         check_success(chfl_guess_format(
-            path.as_ptr(), buffer.as_mut_ptr(), buffer.len() as u64
+            path.as_ptr(),
+            buffer.as_mut_ptr(),
+            buffer.len() as u64,
         ));
     }
     return crate::strings::from_c(buffer.as_ptr());

--- a/src/property.rs
+++ b/src/property.rs
@@ -21,7 +21,7 @@ impl RawProperty {
     }
 
     /// Get the underlying C pointer as a const pointer.
-    pub fn as_ptr(&self) -> *const CHFL_PROPERTY {
+    pub const fn as_ptr(&self) -> *const CHFL_PROPERTY {
         self.handle
     }
 

--- a/src/property.rs
+++ b/src/property.rs
@@ -1,7 +1,6 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
-use std::ops::Drop;
-use std::vec::IntoIter;
+use std::{ops::Drop, vec::IntoIter};
 
 use chemfiles_sys::*;
 use errors::{check, check_not_null, check_success, Error};
@@ -18,9 +17,7 @@ impl RawProperty {
     /// This function is unsafe because no validity check is made on the pointer.
     pub unsafe fn from_ptr(ptr: *mut CHFL_PROPERTY) -> RawProperty {
         check_not_null(ptr);
-        RawProperty {
-            handle: ptr
-        }
+        RawProperty { handle: ptr }
     }
 
     /// Get the underlying C pointer as a const pointer.
@@ -91,7 +88,10 @@ impl RawProperty {
     fn get_vector3d(&self) -> Result<[f64; 3], Error> {
         let mut value = [0.0; 3];
         unsafe {
-            check(chfl_property_get_vector3d(self.as_ptr(), value.as_mut_ptr()))?;
+            check(chfl_property_get_vector3d(
+                self.as_ptr(),
+                value.as_mut_ptr(),
+            ))?;
         }
         return Ok(value);
     }
@@ -159,7 +159,7 @@ impl Property {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]  // raw property
+    #[allow(clippy::needless_pass_by_value)] // raw property
     pub(crate) fn from_raw(raw: RawProperty) -> Property {
         match raw.get_kind() {
             chfl_property_kind::CHFL_PROPERTY_BOOL => {
@@ -179,7 +179,7 @@ impl Property {
 }
 
 /// An iterator over the properties in an atom/frame/residue
-pub struct PropertiesIter<'a> where  {
+pub struct PropertiesIter<'a> {
     pub(crate) names: IntoIter<String>,
     pub(crate) getter: Box<dyn Fn(&str) -> Property + 'a>,
 }
@@ -217,21 +217,30 @@ mod tests {
         #[test]
         fn double() {
             let property = RawProperty::double(45.0);
-            assert_eq!(property.get_kind(), chfl_property_kind::CHFL_PROPERTY_DOUBLE);
+            assert_eq!(
+                property.get_kind(),
+                chfl_property_kind::CHFL_PROPERTY_DOUBLE
+            );
             assert_eq!(property.get_double(), Ok(45.0));
         }
 
         #[test]
         fn string() {
             let property = RawProperty::string("test");
-            assert_eq!(property.get_kind(), chfl_property_kind::CHFL_PROPERTY_STRING);
+            assert_eq!(
+                property.get_kind(),
+                chfl_property_kind::CHFL_PROPERTY_STRING
+            );
             assert_eq!(property.get_string(), Ok("test".into()));
         }
 
         #[test]
         fn vector3d() {
             let property = RawProperty::vector3d([1.2, 3.4, 5.6]);
-            assert_eq!(property.get_kind(), chfl_property_kind::CHFL_PROPERTY_VECTOR3D);
+            assert_eq!(
+                property.get_kind(),
+                chfl_property_kind::CHFL_PROPERTY_VECTOR3D
+            );
             assert_eq!(property.get_vector3d(), Ok([1.2, 3.4, 5.6]));
         }
     }

--- a/src/residue.rs
+++ b/src/residue.rs
@@ -32,10 +32,10 @@ impl<'a> Deref for ResidueRef<'a> {
 }
 
 impl Clone for Residue {
-    fn clone(&self) -> Residue {
+    fn clone(&self) -> Self {
         unsafe {
             let new_handle = chfl_residue_copy(self.as_ptr());
-            Residue::from_ptr(new_handle)
+            Self::from_ptr(new_handle)
         }
     }
 }
@@ -45,9 +45,9 @@ impl Residue {
     ///
     /// This function is unsafe because no validity check is made on the pointer.
     #[inline]
-    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_RESIDUE) -> Residue {
+    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_RESIDUE) -> Self {
         check_not_null(ptr);
-        Residue { handle: ptr }
+        Self { handle: ptr }
     }
 
     /// Create a borrowed `Residue` from a C pointer.
@@ -58,7 +58,7 @@ impl Residue {
     #[inline]
     pub(crate) unsafe fn ref_from_ptr<'a>(ptr: *const CHFL_RESIDUE) -> ResidueRef<'a> {
         ResidueRef {
-            inner: Residue::from_ptr(ptr as *mut CHFL_RESIDUE),
+            inner: Self::from_ptr(ptr as *mut CHFL_RESIDUE),
             marker: PhantomData,
         }
     }
@@ -84,11 +84,11 @@ impl Residue {
     /// assert_eq!(residue.name(), "ALA");
     /// assert_eq!(residue.id(), None);
     /// ```
-    pub fn new<'a>(name: impl Into<&'a str>) -> Residue {
+    pub fn new<'a>(name: impl Into<&'a str>) -> Self {
         let buffer = strings::to_c(name.into());
         unsafe {
             let handle = chfl_residue(buffer.as_ptr());
-            Residue::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 
@@ -101,11 +101,11 @@ impl Residue {
     /// assert_eq!(residue.name(), "ALA");
     /// assert_eq!(residue.id(), Some(67));
     /// ```
-    pub fn with_id<'a>(name: impl Into<&'a str>, id: i64) -> Residue {
+    pub fn with_id<'a>(name: impl Into<&'a str>, id: i64) -> Self {
         let buffer = strings::to_c(name.into());
         unsafe {
             let handle = chfl_residue_with_id(buffer.as_ptr(), id);
-            Residue::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 

--- a/src/residue.rs
+++ b/src/residue.rs
@@ -1,12 +1,14 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
-use std::ops::{Drop, Deref};
-use std::marker::PhantomData;
-use std::ptr;
+use std::{
+    marker::PhantomData,
+    ops::{Deref, Drop},
+    ptr,
+};
 
 use chemfiles_sys::*;
 use errors::{check_not_null, check_success};
-use property::{Property, RawProperty, PropertiesIter};
+use property::{PropertiesIter, Property, RawProperty};
 use strings;
 
 /// A `Residue` is a group of atoms belonging to the same logical unit. They
@@ -19,7 +21,7 @@ pub struct Residue {
 /// An analog to a reference to a residue (`&Residue`)
 pub struct ResidueRef<'a> {
     inner: Residue,
-    marker: PhantomData<&'a Residue>
+    marker: PhantomData<&'a Residue>,
 }
 
 impl<'a> Deref for ResidueRef<'a> {
@@ -45,9 +47,7 @@ impl Residue {
     #[inline]
     pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_RESIDUE) -> Residue {
         check_not_null(ptr);
-        Residue {
-            handle: ptr
-        }
+        Residue { handle: ptr }
     }
 
     /// Create a borrowed `Residue` from a C pointer.
@@ -141,9 +141,7 @@ impl Residue {
     /// ```
     pub fn id(&self) -> Option<i64> {
         let mut resid = 0;
-        let status = unsafe {
-            chfl_residue_id(self.as_ptr(), &mut resid)
-        };
+        let status = unsafe { chfl_residue_id(self.as_ptr(), &mut resid) };
 
         if status == chfl_status::CHFL_SUCCESS {
             return Some(resid);
@@ -166,7 +164,8 @@ impl Residue {
     /// ```
     pub fn name(&self) -> String {
         let get_name = |ptr, len| unsafe { chfl_residue_name(self.as_ptr(), ptr, len) };
-        let name = strings::call_autogrow_buffer(64, get_name).expect("getting residue name failed");
+        let name =
+            strings::call_autogrow_buffer(64, get_name).expect("getting residue name failed");
         return strings::from_c(name.as_ptr());
     }
 
@@ -209,7 +208,11 @@ impl Residue {
     pub fn contains(&self, atom: usize) -> bool {
         let mut inside = 0;
         unsafe {
-            check_success(chfl_residue_contains(self.as_ptr(), atom as u64, &mut inside));
+            check_success(chfl_residue_contains(
+                self.as_ptr(),
+                atom as u64,
+                &mut inside,
+            ));
         }
         return inside != 0;
     }
@@ -260,7 +263,9 @@ impl Residue {
         let property = property.into().as_raw();
         unsafe {
             check_success(chfl_residue_set_property(
-                self.as_mut_ptr(), buffer.as_ptr(), property.as_ptr()
+                self.as_mut_ptr(),
+                buffer.as_ptr(),
+                property.as_ptr(),
             ));
         }
     }
@@ -316,7 +321,11 @@ impl Residue {
         let size = count as usize;
         let mut c_names = vec![ptr::null_mut(); size];
         unsafe {
-            check_success(chfl_residue_list_properties(self.as_ptr(), c_names.as_mut_ptr(), count));
+            check_success(chfl_residue_list_properties(
+                self.as_ptr(),
+                c_names.as_mut_ptr(),
+                count,
+            ));
         }
 
         let mut names = Vec::new();
@@ -326,7 +335,7 @@ impl Residue {
 
         PropertiesIter {
             names: names.into_iter(),
-            getter: Box::new(move |name| self.get(name).expect("failed to get property"))
+            getter: Box::new(move |name| self.get(name).expect("failed to get property")),
         }
     }
 }

--- a/src/residue.rs
+++ b/src/residue.rs
@@ -65,7 +65,7 @@ impl Residue {
 
     /// Get the underlying C pointer as a const pointer.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *const CHFL_RESIDUE {
+    pub(crate) const fn as_ptr(&self) -> *const CHFL_RESIDUE {
         self.handle
     }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,13 +1,15 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
-use std::ops::{Drop, Index};
-use std::iter::IntoIterator;
-use std::slice::Iter;
+use std::{
+    iter::IntoIterator,
+    ops::{Drop, Index},
+    slice::Iter,
+};
 
 use chemfiles_sys::*;
 use errors::{check, check_not_null, check_success, Error, Status};
-use strings;
 use frame::Frame;
+use strings;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// A `Match` is a set of atomic indexes matching a given selection. It can
@@ -130,9 +132,7 @@ impl Selection {
     #[inline]
     pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_SELECTION) -> Selection {
         check_not_null(ptr);
-        Selection {
-            handle: ptr
-        }
+        Selection { handle: ptr }
     }
 
     /// Get the underlying C pointer as a const pointer.
@@ -165,7 +165,7 @@ impl Selection {
             if handle.is_null() {
                 Err(Error {
                     status: Status::SelectionError,
-                    message: Error::last_error()
+                    message: Error::last_error(),
                 })
             } else {
                 Ok(Selection::from_ptr(handle))
@@ -205,7 +205,8 @@ impl Selection {
     /// ```
     pub fn string(&self) -> String {
         let get_string = |ptr, len| unsafe { chfl_selection_string(self.as_ptr(), ptr, len) };
-        let selection = strings::call_autogrow_buffer(1024, get_string).expect("failed to get selection string");
+        let selection = strings::call_autogrow_buffer(1024, get_string)
+            .expect("failed to get selection string");
         return strings::from_c(selection.as_ptr());
     }
 
@@ -238,21 +239,32 @@ impl Selection {
         let mut count = 0;
         unsafe {
             check(chfl_selection_evaluate(
-                self.as_mut_ptr(), frame.as_ptr(), &mut count
-            )).expect("failed to evaluate selection");
+                self.as_mut_ptr(),
+                frame.as_ptr(),
+                &mut count,
+            ))
+            .expect("failed to evaluate selection");
         }
 
         let size = count as usize;
-        let mut chfl_matches = vec![chfl_match { size: 0, atoms: [0; 4] }; size];
+        let mut chfl_matches = vec![
+            chfl_match {
+                size: 0,
+                atoms: [0; 4]
+            };
+            size
+        ];
         unsafe {
             check(chfl_selection_matches(
                 self.handle,
                 chfl_matches.as_mut_ptr(),
-                count
-            )).expect("failed to extract matches");
+                count,
+            ))
+            .expect("failed to extract matches");
         }
 
-        return chfl_matches.into_iter()
+        return chfl_matches
+            .into_iter()
             .map(|chfl_match| Match {
                 size: chfl_match.size as usize,
                 atoms: [
@@ -291,7 +303,8 @@ impl Selection {
         if self.size() != 1 {
             panic!("can not call `Selection::list` on a multiple selection");
         }
-        return self.evaluate(frame)
+        return self
+            .evaluate(frame)
             .into_iter()
             .map(|m| m[0] as usize)
             .collect();
@@ -300,10 +313,11 @@ impl Selection {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use Atom;
     use Frame;
     use Topology;
-    use Atom;
+
+    use super::*;
 
     #[test]
     fn clone() {
@@ -351,7 +365,10 @@ mod tests {
         #[test]
         fn iter() {
             let match_ = Match::new(&[1, 2, 3, 4]);
-            assert_eq!(match_.iter().copied().collect::<Vec<usize>>(), vec![1, 2, 3, 4]);
+            assert_eq!(
+                match_.iter().copied().collect::<Vec<usize>>(),
+                vec![1, 2, 3, 4]
+            );
 
             let v = vec![1, 2, 3, 4];
             for (i, &m) in match_.iter().enumerate() {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -51,14 +51,14 @@ impl Match {
     /// assert_eq!(atomic_match[1], 4);
     /// assert_eq!(atomic_match[2], 5);
     /// ```
-    pub fn new(atoms: &[usize]) -> Match {
+    pub fn new(atoms: &[usize]) -> Self {
         assert!(atoms.len() <= 4);
         let size = atoms.len();
         let mut matches = [usize::max_value(); 4];
         for (i, atom) in atoms.iter().enumerate() {
             matches[i] = *atom;
         }
-        Match {
+        Self {
             size,
             atoms: matches,
         }
@@ -109,10 +109,10 @@ pub struct Selection {
 }
 
 impl Clone for Selection {
-    fn clone(&self) -> Selection {
+    fn clone(&self) -> Self {
         unsafe {
             let new_handle = chfl_selection_copy(self.as_ptr());
-            Selection::from_ptr(new_handle)
+            Self::from_ptr(new_handle)
         }
     }
 }
@@ -130,9 +130,9 @@ impl Selection {
     ///
     /// This function is unsafe because no validity check is made on the pointer.
     #[inline]
-    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_SELECTION) -> Selection {
+    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_SELECTION) -> Self {
         check_not_null(ptr);
-        Selection { handle: ptr }
+        Self { handle: ptr }
     }
 
     /// Get the underlying C pointer as a const pointer.
@@ -158,7 +158,7 @@ impl Selection {
     /// # use chemfiles::Selection;
     /// let selection = Selection::new("pairs: name(#1) H and name(#2) O").unwrap();
     /// ```
-    pub fn new<'a, S: Into<&'a str>>(selection: S) -> Result<Selection, Error> {
+    pub fn new<'a, S: Into<&'a str>>(selection: S) -> Result<Self, Error> {
         let buffer = strings::to_c(selection.into());
         unsafe {
             let handle = chfl_selection(buffer.as_ptr());
@@ -168,7 +168,7 @@ impl Selection {
                     message: Error::last_error(),
                 })
             } else {
-                Ok(Selection::from_ptr(handle))
+                Ok(Self::from_ptr(handle))
             }
         }
     }
@@ -303,11 +303,7 @@ impl Selection {
         if self.size() != 1 {
             panic!("can not call `Selection::list` on a multiple selection");
         }
-        return self
-            .evaluate(frame)
-            .into_iter()
-            .map(|m| m[0] as usize)
-            .collect();
+        return self.evaluate(frame).into_iter().map(|m| m[0]).collect();
     }
 }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -30,7 +30,7 @@ impl Match {
     /// let atomic_match = Match::new(&[3, 4, 5]);
     /// assert_eq!(atomic_match.len(), 3);
     /// ```
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.size
     }
 
@@ -137,7 +137,7 @@ impl Selection {
 
     /// Get the underlying C pointer as a const pointer.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *const CHFL_SELECTION {
+    pub(crate) const fn as_ptr(&self) -> *const CHFL_SELECTION {
         self.handle
     }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -21,7 +21,10 @@ pub fn from_c(buffer: *const c_char) -> String {
 }
 
 /// Create a C string from a Rust string.
-pub fn to_c(string: &str) -> CString {
+pub fn to_c<S>(string: S) -> CString
+where
+    S: Into<Vec<u8>>,
+{
     CString::new(string).expect("Invalid C string from Rust")
 }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -2,8 +2,10 @@
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
 
 //! String conversions between C and Rust
-use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
+use std::{
+    ffi::{CStr, CString},
+    os::raw::c_char,
+};
 
 use chemfiles_sys::chfl_status;
 use errors::{check, Error};

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -1,12 +1,14 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
-use std::ops::{Drop, Deref};
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    ops::{Deref, Drop},
+};
 
 use chemfiles_sys::*;
 use errors::{check, check_not_null, check_success, Error};
-use super::{Atom, AtomRef, AtomMut};
-use super::{Residue, ResidueRef};
+
+use super::{Atom, AtomMut, AtomRef, Residue, ResidueRef};
 
 /// Possible bond order associated with bonds
 #[repr(C)]
@@ -71,7 +73,7 @@ pub struct Topology {
 /// An analog to a reference to a topology (`&Topology`)
 pub struct TopologyRef<'a> {
     inner: Topology,
-    marker: PhantomData<&'a Topology>
+    marker: PhantomData<&'a Topology>,
 }
 
 impl<'a> Deref for TopologyRef<'a> {
@@ -98,9 +100,7 @@ impl Topology {
     #[inline]
     pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_TOPOLOGY) -> Topology {
         check_not_null(ptr);
-        Topology {
-            handle: ptr
-        }
+        Topology { handle: ptr }
     }
 
     /// Create a borrowed `Topology` from a C pointer.
@@ -148,9 +148,7 @@ impl Topology {
     /// assert_eq!(topology.size(), 0);
     /// ```
     pub fn new() -> Topology {
-        unsafe {
-            Topology::from_ptr(chfl_topology())
-        }
+        unsafe { Topology::from_ptr(chfl_topology()) }
     }
 
     /// Get a reference of the atom at the given `index` in this topology.
@@ -170,9 +168,8 @@ impl Topology {
     /// ```
     pub fn atom(&self, index: usize) -> AtomRef {
         unsafe {
-            let handle = chfl_atom_from_topology(
-                self.as_mut_ptr_MANUALLY_CHECKING_BORROW(), index as u64
-            );
+            let handle =
+                chfl_atom_from_topology(self.as_mut_ptr_MANUALLY_CHECKING_BORROW(), index as u64);
             Atom::ref_from_ptr(handle)
         }
     }
@@ -196,9 +193,7 @@ impl Topology {
     /// ```
     pub fn atom_mut(&mut self, index: usize) -> AtomMut {
         unsafe {
-            let handle = chfl_atom_from_topology(
-                self.as_mut_ptr(), index as u64
-            );
+            let handle = chfl_atom_from_topology(self.as_mut_ptr(), index as u64);
             Atom::ref_mut_from_ptr(handle)
         }
     }
@@ -391,7 +386,11 @@ impl Topology {
         let count = size as u64;
         let mut bonds = vec![[u64::max_value(); 2]; size];
         unsafe {
-            check_success(chfl_topology_bonds(self.as_ptr(), bonds.as_mut_ptr(), count));
+            check_success(chfl_topology_bonds(
+                self.as_ptr(),
+                bonds.as_mut_ptr(),
+                count,
+            ));
         }
         #[allow(clippy::cast_possible_truncation)]
         return bonds
@@ -418,7 +417,11 @@ impl Topology {
         let count = size as u64;
         let mut angles = vec![[u64::max_value(); 3]; size];
         unsafe {
-            check_success(chfl_topology_angles(self.as_ptr(), angles.as_mut_ptr(), count));
+            check_success(chfl_topology_angles(
+                self.as_ptr(),
+                angles.as_mut_ptr(),
+                count,
+            ));
         }
         #[allow(clippy::cast_possible_truncation)]
         return angles
@@ -447,7 +450,9 @@ impl Topology {
         let mut dihedrals = vec![[u64::max_value(); 4]; size];
         unsafe {
             check_success(chfl_topology_dihedrals(
-                self.as_ptr(), dihedrals.as_mut_ptr(), count
+                self.as_ptr(),
+                dihedrals.as_mut_ptr(),
+                count,
             ));
         }
         #[allow(clippy::cast_possible_truncation)]
@@ -484,7 +489,9 @@ impl Topology {
         let mut impropers = vec![[u64::max_value(); 4]; size];
         unsafe {
             check_success(chfl_topology_impropers(
-                self.as_ptr(), impropers.as_mut_ptr(), count
+                self.as_ptr(),
+                impropers.as_mut_ptr(),
+                count,
             ));
         }
         #[allow(clippy::cast_possible_truncation)]
@@ -544,7 +551,11 @@ impl Topology {
     /// ```
     pub fn add_bond(&mut self, i: usize, j: usize) {
         unsafe {
-            check_success(chfl_topology_add_bond(self.as_mut_ptr(), i as u64, j as u64));
+            check_success(chfl_topology_add_bond(
+                self.as_mut_ptr(),
+                i as u64,
+                j as u64,
+            ));
         }
     }
 
@@ -564,7 +575,10 @@ impl Topology {
     pub fn add_bond_with_order(&mut self, i: usize, j: usize, order: BondOrder) {
         unsafe {
             check_success(chfl_topology_bond_with_order(
-                self.as_mut_ptr(), i as u64, j as u64, order.as_raw()
+                self.as_mut_ptr(),
+                i as u64,
+                j as u64,
+                order.as_raw(),
             ));
         }
     }
@@ -586,10 +600,13 @@ impl Topology {
         let mut order = chfl_bond_order::CHFL_BOND_UNKNOWN;
         unsafe {
             check_success(chfl_topology_bond_order(
-                self.as_ptr(), i as u64, j as u64, &mut order
+                self.as_ptr(),
+                i as u64,
+                j as u64,
+                &mut order,
             ));
         }
-        return order.into()
+        return order.into();
     }
 
     /// Get the bond order for all the bonds in the topology
@@ -616,7 +633,7 @@ impl Topology {
                 // Casting BondOrder to chfl_bond_order is safe, as they are
                 // both `repr(C)` enums with the same values.
                 bonds.as_mut_ptr().cast(),
-                count
+                count,
             ));
         }
         return bonds;
@@ -647,7 +664,11 @@ impl Topology {
     /// ```
     pub fn remove_bond(&mut self, i: usize, j: usize) {
         unsafe {
-            check_success(chfl_topology_remove_bond(self.as_mut_ptr(), i as u64, j as u64));
+            check_success(chfl_topology_remove_bond(
+                self.as_mut_ptr(),
+                i as u64,
+                j as u64,
+            ));
         }
     }
 
@@ -697,15 +718,11 @@ impl Topology {
     /// assert!(topology.residue_for_atom(6).is_none());
     /// ```
     pub fn residue_for_atom(&self, index: usize) -> Option<ResidueRef> {
-        let handle = unsafe {
-            chfl_residue_for_atom(self.as_ptr(), index as u64)
-        };
+        let handle = unsafe { chfl_residue_for_atom(self.as_ptr(), index as u64) };
         if handle.is_null() {
             None
         } else {
-            unsafe {
-                Some(Residue::ref_from_ptr(handle))
-            }
+            unsafe { Some(Residue::ref_from_ptr(handle)) }
         }
     }
 
@@ -747,7 +764,10 @@ impl Topology {
     /// ```
     pub fn add_residue(&mut self, residue: &Residue) -> Result<(), Error> {
         unsafe {
-            check(chfl_topology_add_residue(self.as_mut_ptr(), residue.as_ptr()))
+            check(chfl_topology_add_residue(
+                self.as_mut_ptr(),
+                residue.as_ptr(),
+            ))
         }
     }
 
@@ -774,7 +794,7 @@ impl Topology {
                 self.as_ptr(),
                 first.as_ptr(),
                 second.as_ptr(),
-                &mut linked
+                &mut linked,
             ));
         }
         return linked != 0;
@@ -791,8 +811,10 @@ impl Drop for Topology {
 
 #[cfg(test)]
 mod test {
+    use Atom;
+    use Residue;
+
     use super::*;
-    use {Atom, Residue};
 
     #[test]
     fn clone() {
@@ -858,7 +880,6 @@ mod test {
         topology.resize(18);
         topology.remove(33);
     }
-
 
     #[test]
     fn bonds() {

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -36,29 +36,29 @@ pub enum BondOrder {
 impl BondOrder {
     pub(crate) fn as_raw(self) -> chfl_bond_order {
         match self {
-            BondOrder::Unknown => chfl_bond_order::CHFL_BOND_UNKNOWN,
-            BondOrder::Single => chfl_bond_order::CHFL_BOND_SINGLE,
-            BondOrder::Double => chfl_bond_order::CHFL_BOND_DOUBLE,
-            BondOrder::Triple => chfl_bond_order::CHFL_BOND_TRIPLE,
-            BondOrder::Quadruple => chfl_bond_order::CHFL_BOND_QUADRUPLE,
-            BondOrder::Quintuplet => chfl_bond_order::CHFL_BOND_QUINTUPLET,
-            BondOrder::Amide => chfl_bond_order::CHFL_BOND_AMIDE,
-            BondOrder::Aromatic => chfl_bond_order::CHFL_BOND_AROMATIC,
+            Self::Unknown => chfl_bond_order::CHFL_BOND_UNKNOWN,
+            Self::Single => chfl_bond_order::CHFL_BOND_SINGLE,
+            Self::Double => chfl_bond_order::CHFL_BOND_DOUBLE,
+            Self::Triple => chfl_bond_order::CHFL_BOND_TRIPLE,
+            Self::Quadruple => chfl_bond_order::CHFL_BOND_QUADRUPLE,
+            Self::Quintuplet => chfl_bond_order::CHFL_BOND_QUINTUPLET,
+            Self::Amide => chfl_bond_order::CHFL_BOND_AMIDE,
+            Self::Aromatic => chfl_bond_order::CHFL_BOND_AROMATIC,
         }
     }
 }
 
 impl From<chfl_bond_order> for BondOrder {
-    fn from(order: chfl_bond_order) -> BondOrder {
+    fn from(order: chfl_bond_order) -> Self {
         match order {
-            chfl_bond_order::CHFL_BOND_UNKNOWN => BondOrder::Unknown,
-            chfl_bond_order::CHFL_BOND_SINGLE => BondOrder::Single,
-            chfl_bond_order::CHFL_BOND_DOUBLE => BondOrder::Double,
-            chfl_bond_order::CHFL_BOND_TRIPLE => BondOrder::Triple,
-            chfl_bond_order::CHFL_BOND_QUADRUPLE => BondOrder::Quadruple,
-            chfl_bond_order::CHFL_BOND_QUINTUPLET => BondOrder::Quintuplet,
-            chfl_bond_order::CHFL_BOND_AMIDE => BondOrder::Amide,
-            chfl_bond_order::CHFL_BOND_AROMATIC => BondOrder::Aromatic,
+            chfl_bond_order::CHFL_BOND_UNKNOWN => Self::Unknown,
+            chfl_bond_order::CHFL_BOND_SINGLE => Self::Single,
+            chfl_bond_order::CHFL_BOND_DOUBLE => Self::Double,
+            chfl_bond_order::CHFL_BOND_TRIPLE => Self::Triple,
+            chfl_bond_order::CHFL_BOND_QUADRUPLE => Self::Quadruple,
+            chfl_bond_order::CHFL_BOND_QUINTUPLET => Self::Quintuplet,
+            chfl_bond_order::CHFL_BOND_AMIDE => Self::Amide,
+            chfl_bond_order::CHFL_BOND_AROMATIC => Self::Aromatic,
         }
     }
 }
@@ -84,10 +84,10 @@ impl<'a> Deref for TopologyRef<'a> {
 }
 
 impl Clone for Topology {
-    fn clone(&self) -> Topology {
+    fn clone(&self) -> Self {
         unsafe {
             let new_handle = chfl_topology_copy(self.as_ptr());
-            Topology::from_ptr(new_handle)
+            Self::from_ptr(new_handle)
         }
     }
 }
@@ -98,9 +98,9 @@ impl Topology {
     /// This function is unsafe because no validity check is made on the pointer,
     /// except for it being non-null.
     #[inline]
-    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_TOPOLOGY) -> Topology {
+    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_TOPOLOGY) -> Self {
         check_not_null(ptr);
-        Topology { handle: ptr }
+        Self { handle: ptr }
     }
 
     /// Create a borrowed `Topology` from a C pointer.
@@ -111,7 +111,7 @@ impl Topology {
     #[inline]
     pub(crate) unsafe fn ref_from_ptr<'a>(ptr: *const CHFL_TOPOLOGY) -> TopologyRef<'a> {
         TopologyRef {
-            inner: Topology::from_ptr(ptr as *mut CHFL_TOPOLOGY),
+            inner: Self::from_ptr(ptr as *mut CHFL_TOPOLOGY),
             marker: PhantomData,
         }
     }
@@ -147,8 +147,8 @@ impl Topology {
     /// let topology = Topology::new();
     /// assert_eq!(topology.size(), 0);
     /// ```
-    pub fn new() -> Topology {
-        unsafe { Topology::from_ptr(chfl_topology()) }
+    pub fn new() -> Self {
+        unsafe { Self::from_ptr(chfl_topology()) }
     }
 
     /// Get a reference of the atom at the given `index` in this topology.
@@ -688,7 +688,7 @@ impl Topology {
     /// ```
     pub fn residue(&self, index: u64) -> Option<ResidueRef> {
         unsafe {
-            let handle = chfl_residue_from_topology(self.as_ptr(), index as u64);
+            let handle = chfl_residue_from_topology(self.as_ptr(), index);
             if handle.is_null() {
                 None
             } else {

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -34,7 +34,7 @@ pub enum BondOrder {
 }
 
 impl BondOrder {
-    pub(crate) fn as_raw(self) -> chfl_bond_order {
+    pub(crate) const fn as_raw(self) -> chfl_bond_order {
         match self {
             Self::Unknown => chfl_bond_order::CHFL_BOND_UNKNOWN,
             Self::Single => chfl_bond_order::CHFL_BOND_SINGLE,
@@ -118,7 +118,7 @@ impl Topology {
 
     /// Get the underlying C pointer as a const pointer.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *const CHFL_TOPOLOGY {
+    pub(crate) const fn as_ptr(&self) -> *const CHFL_TOPOLOGY {
         self.handle
     }
 
@@ -135,7 +135,7 @@ impl Topology {
     /// mutable borrows
     #[inline]
     #[allow(non_snake_case)]
-    pub(crate) fn as_mut_ptr_MANUALLY_CHECKING_BORROW(&self) -> *mut CHFL_TOPOLOGY {
+    pub(crate) const fn as_mut_ptr_MANUALLY_CHECKING_BORROW(&self) -> *mut CHFL_TOPOLOGY {
         self.handle
     }
 

--- a/src/trajectory.rs
+++ b/src/trajectory.rs
@@ -21,14 +21,14 @@ impl Trajectory {
     ///
     /// This function is unsafe because no validity check is made on the pointer.
     #[inline]
-    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_TRAJECTORY) -> Result<Trajectory, Error> {
+    pub(crate) unsafe fn from_ptr(ptr: *mut CHFL_TRAJECTORY) -> Result<Self, Error> {
         if ptr.is_null() {
             Err(Error {
                 status: Status::FileError,
                 message: Error::last_error(),
             })
         } else {
-            Ok(Trajectory { handle: ptr })
+            Ok(Self { handle: ptr })
         }
     }
 
@@ -59,7 +59,7 @@ impl Trajectory {
     /// # use chemfiles::Trajectory;
     /// let trajectory = Trajectory::open("water.xyz", 'r').unwrap();
     /// ```
-    pub fn open<P>(path: P, mode: char) -> Result<Trajectory, Error>
+    pub fn open<P>(path: P, mode: char) -> Result<Self, Error>
     where
         P: AsRef<Path>,
     {
@@ -72,7 +72,7 @@ impl Trajectory {
         unsafe {
             #[allow(clippy::cast_possible_wrap)]
             let handle = chfl_trajectory_open(path.as_ptr(), mode as c_char);
-            Trajectory::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 
@@ -97,11 +97,7 @@ impl Trajectory {
     /// # use chemfiles::Trajectory;
     /// let trajectory = Trajectory::open_with_format("water.zeo", 'r', "XYZ").unwrap();
     /// ```
-    pub fn open_with_format<'a, P, S>(
-        filename: P,
-        mode: char,
-        format: S,
-    ) -> Result<Trajectory, Error>
+    pub fn open_with_format<'a, P, S>(filename: P, mode: char, format: S) -> Result<Self, Error>
     where
         P: AsRef<Path>,
         S: Into<&'a str>,
@@ -117,7 +113,7 @@ impl Trajectory {
             #[allow(clippy::cast_possible_wrap)]
             let handle =
                 chfl_trajectory_with_format(filename.as_ptr(), mode as c_char, format.as_ptr());
-            Trajectory::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 
@@ -141,7 +137,7 @@ impl Trajectory {
     /// trajectory.read(&mut frame).unwrap();
     /// assert_eq!(frame.size(), 6);
     /// ```
-    pub fn memory_reader<'a, S>(data: S, format: S) -> Result<Trajectory, Error>
+    pub fn memory_reader<'a, S>(data: S, format: S) -> Result<Self, Error>
     where
         S: Into<&'a str>,
     {
@@ -153,7 +149,7 @@ impl Trajectory {
                 data.as_bytes().len() as u64,
                 format.as_ptr(),
             );
-            Trajectory::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 
@@ -178,14 +174,14 @@ impl Trajectory {
     /// // Binary formats typically do not support this feature
     /// assert!(Trajectory::memory_writer("XTC").is_err());
     /// ```
-    pub fn memory_writer<'a, S>(format: S) -> Result<Trajectory, Error>
+    pub fn memory_writer<'a, S>(format: S) -> Result<Self, Error>
     where
         S: Into<&'a str>,
     {
         let format = strings::to_c(format.into());
         unsafe {
             let handle = chfl_trajectory_memory_writer(format.as_ptr());
-            Trajectory::from_ptr(handle)
+            Self::from_ptr(handle)
         }
     }
 

--- a/src/trajectory.rs
+++ b/src/trajectory.rs
@@ -548,7 +548,10 @@ mod test {
         assert_eq!(frame.size(), 125);
     }
 
-    fn write_file(path: &str) {
+    fn write_file<P>(path: P)
+    where
+        P: AsRef<Path>,
+    {
         let mut file = Trajectory::open(path, 'w').unwrap();
         let mut frame = Frame::new();
         frame.resize(4);

--- a/src/trajectory.rs
+++ b/src/trajectory.rs
@@ -34,7 +34,7 @@ impl Trajectory {
 
     /// Get the underlying C pointer as a pointer.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *const CHFL_TRAJECTORY {
+    pub(crate) const fn as_ptr(&self) -> *const CHFL_TRAJECTORY {
         self.handle
     }
 

--- a/src/trajectory.rs
+++ b/src/trajectory.rs
@@ -1,15 +1,13 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) 2015-2018 Guillaume Fraux -- BSD licensed
-use std::convert::TryInto;
-use std::path::Path;
-use std::ptr;
-use std::os::raw::c_char;
+use std::{convert::TryInto, os::raw::c_char, path::Path, ptr};
 
 use chemfiles_sys::*;
 use errors::{check, check_success, Error, Status};
 use strings;
-
-use {Frame, Topology, UnitCell};
+use Frame;
+use Topology;
+use UnitCell;
 
 /// The `Trajectory` type is the main entry point when using chemfiles. A
 /// `Trajectory` behave a bit like a file, allowing to read and/or write
@@ -27,12 +25,10 @@ impl Trajectory {
         if ptr.is_null() {
             Err(Error {
                 status: Status::FileError,
-                message: Error::last_error()
+                message: Error::last_error(),
             })
         } else {
-            Ok(Trajectory {
-                handle: ptr
-            })
+            Ok(Trajectory { handle: ptr })
         }
     }
 
@@ -67,7 +63,10 @@ impl Trajectory {
     where
         P: AsRef<Path>,
     {
-        let path = path.as_ref().to_str().ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
+        let path = path
+            .as_ref()
+            .to_str()
+            .ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
 
         let path = strings::to_c(path);
         unsafe {
@@ -98,21 +97,26 @@ impl Trajectory {
     /// # use chemfiles::Trajectory;
     /// let trajectory = Trajectory::open_with_format("water.zeo", 'r', "XYZ").unwrap();
     /// ```
-    pub fn open_with_format<'a, P, S>(filename: P, mode: char, format: S) -> Result<Trajectory, Error>
+    pub fn open_with_format<'a, P, S>(
+        filename: P,
+        mode: char,
+        format: S,
+    ) -> Result<Trajectory, Error>
     where
         P: AsRef<Path>,
         S: Into<&'a str>,
     {
-        let filename =
-            filename.as_ref().to_str().ok_or_else(|| Error::utf8_path_error(filename.as_ref()))?;
+        let filename = filename
+            .as_ref()
+            .to_str()
+            .ok_or_else(|| Error::utf8_path_error(filename.as_ref()))?;
 
         let filename = strings::to_c(filename);
         let format = strings::to_c(format.into());
         unsafe {
             #[allow(clippy::cast_possible_wrap)]
-            let handle = chfl_trajectory_with_format(
-                filename.as_ptr(), mode as c_char, format.as_ptr()
-            );
+            let handle =
+                chfl_trajectory_with_format(filename.as_ptr(), mode as c_char, format.as_ptr());
             Trajectory::from_ptr(handle)
         }
     }
@@ -138,13 +142,16 @@ impl Trajectory {
     /// assert_eq!(frame.size(), 6);
     /// ```
     pub fn memory_reader<'a, S>(data: S, format: S) -> Result<Trajectory, Error>
-    where S: Into<&'a str>,
+    where
+        S: Into<&'a str>,
     {
         let data = strings::to_c(data.into());
         let format = strings::to_c(format.into());
         unsafe {
             let handle = chfl_trajectory_memory_reader(
-                data.as_ptr(), data.as_bytes().len() as u64, format.as_ptr()
+                data.as_ptr(),
+                data.as_bytes().len() as u64,
+                format.as_ptr(),
             );
             Trajectory::from_ptr(handle)
         }
@@ -172,7 +179,8 @@ impl Trajectory {
     /// assert!(Trajectory::memory_writer("XTC").is_err());
     /// ```
     pub fn memory_writer<'a, S>(format: S) -> Result<Trajectory, Error>
-    where S: Into<&'a str>,
+    where
+        S: Into<&'a str>,
     {
         let format = strings::to_c(format.into());
         unsafe {
@@ -200,9 +208,7 @@ impl Trajectory {
     /// trajectory.read(&mut frame).unwrap();
     /// ```
     pub fn read(&mut self, frame: &mut Frame) -> Result<(), Error> {
-        unsafe {
-            check(chfl_trajectory_read(self.as_mut_ptr(), frame.as_mut_ptr()))
-        }
+        unsafe { check(chfl_trajectory_read(self.as_mut_ptr(), frame.as_mut_ptr())) }
     }
 
     /// Read a specific `step` of this trajectory into a `frame`.
@@ -225,7 +231,11 @@ impl Trajectory {
     /// ```
     pub fn read_step(&mut self, step: usize, frame: &mut Frame) -> Result<(), Error> {
         unsafe {
-            check(chfl_trajectory_read_step(self.as_mut_ptr(), step as u64, frame.as_mut_ptr()))
+            check(chfl_trajectory_read_step(
+                self.as_mut_ptr(),
+                step as u64,
+                frame.as_mut_ptr(),
+            ))
         }
     }
 
@@ -245,9 +255,7 @@ impl Trajectory {
     /// trajectory.write(&mut frame).unwrap();
     /// ```
     pub fn write(&mut self, frame: &Frame) -> Result<(), Error> {
-        unsafe {
-            check(chfl_trajectory_write(self.as_mut_ptr(), frame.as_ptr()))
-        }
+        unsafe { check(chfl_trajectory_write(self.as_mut_ptr(), frame.as_ptr())) }
     }
 
     /// Set the `topology` associated with this trajectory. This topology will
@@ -269,7 +277,10 @@ impl Trajectory {
     /// ```
     pub fn set_topology(&mut self, topology: &Topology) {
         unsafe {
-            check_success(chfl_trajectory_set_topology(self.as_mut_ptr(), topology.as_ptr()));
+            check_success(chfl_trajectory_set_topology(
+                self.as_mut_ptr(),
+                topology.as_ptr(),
+            ));
         }
     }
 
@@ -292,11 +303,18 @@ impl Trajectory {
     where
         P: AsRef<Path>,
     {
-        let path = path.as_ref().to_str().ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
+        let path = path
+            .as_ref()
+            .to_str()
+            .ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
 
         let path = strings::to_c(path);
         unsafe {
-            check(chfl_trajectory_topology_file(self.as_mut_ptr(), path.as_ptr(), ptr::null()))
+            check(chfl_trajectory_topology_file(
+                self.as_mut_ptr(),
+                path.as_ptr(),
+                ptr::null(),
+            ))
         }
     }
 
@@ -323,12 +341,19 @@ impl Trajectory {
         P: AsRef<Path>,
         S: Into<&'a str>,
     {
-        let path = path.as_ref().to_str().ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
+        let path = path
+            .as_ref()
+            .to_str()
+            .ok_or_else(|| Error::utf8_path_error(path.as_ref()))?;
 
         let format = strings::to_c(format.into());
         let path = strings::to_c(path);
         unsafe {
-            check(chfl_trajectory_topology_file(self.as_mut_ptr(), path.as_ptr(), format.as_ptr()))
+            check(chfl_trajectory_topology_file(
+                self.as_mut_ptr(),
+                path.as_ptr(),
+                format.as_ptr(),
+            ))
         }
     }
 
@@ -362,9 +387,8 @@ impl Trajectory {
     pub fn nsteps(&mut self) -> usize {
         let mut res = 0;
         unsafe {
-            check(chfl_trajectory_nsteps(self.as_mut_ptr(), &mut res)).expect(
-                "failed to get the number of steps in this trajectory"
-            );
+            check(chfl_trajectory_nsteps(self.as_mut_ptr(), &mut res))
+                .expect("failed to get the number of steps in this trajectory");
         }
         #[allow(clippy::cast_possible_truncation)]
         return res as usize;
@@ -394,17 +418,22 @@ impl Trajectory {
     /// ```
     #[allow(clippy::cast_possible_truncation)]
     pub fn memory_buffer(&self) -> Result<&str, Error> {
-            let mut ptr: *const c_char = std::ptr::null();
-            let mut count: u64 = 0;
-            let buffer = unsafe {
-                check(chfl_trajectory_memory_buffer(self.as_ptr(), &mut ptr, &mut count))?;
-                 std::slice::from_raw_parts(
-                    ptr.cast(), count.try_into().expect("failed to convert u64 to usize")
-                )
-            };
+        let mut ptr: *const c_char = std::ptr::null();
+        let mut count: u64 = 0;
+        let buffer = unsafe {
+            check(chfl_trajectory_memory_buffer(
+                self.as_ptr(),
+                &mut ptr,
+                &mut count,
+            ))?;
+            std::slice::from_raw_parts(
+                ptr.cast(),
+                count.try_into().expect("failed to convert u64 to usize"),
+            )
+        };
 
-            let string = std::str::from_utf8(buffer)?;
-            Ok(string)
+        let string = std::str::from_utf8(buffer)?;
+        Ok(string)
     }
 
     /// Get file path for this trajectory.
@@ -418,7 +447,8 @@ impl Trajectory {
     /// ```
     pub fn path(&self) -> String {
         let get_string = |ptr, len| unsafe { chfl_trajectory_path(self.as_ptr(), ptr, len) };
-        let path = strings::call_autogrow_buffer(1024, get_string).expect("failed to get path string");
+        let path =
+            strings::call_autogrow_buffer(1024, get_string).expect("failed to get path string");
         return strings::from_c(path.as_ptr());
     }
 }
@@ -433,15 +463,16 @@ impl Drop for Trajectory {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
-    use std::fs;
-    use std::path::Path;
-    use std::io::Read;
+    use std::{fs, io::Read, path::Path};
 
     use approx::assert_ulps_eq;
+    use Atom;
+    use CellShape;
+    use Frame;
+    use Topology;
+    use UnitCell;
 
-    use {Atom, CellShape, Frame, Topology, UnitCell};
+    use super::*;
 
     #[test]
     fn read() {
@@ -476,7 +507,6 @@ mod test {
         assert!(file.read_step(41, &mut frame).is_ok());
         let cell = frame.cell().clone();
         assert_eq!(cell.lengths(), [30.0, 30.0, 30.0]);
-
 
         assert_ulps_eq!(frame.positions()[0][0], 0.761277);
         assert_ulps_eq!(frame.positions()[0][1], 8.106125);
@@ -549,7 +579,9 @@ Properties=species:S:1:pos:R:3
 X 1 2 3
 X 1 2 3
 X 1 2 3
-X 1 2 3".lines().collect::<Vec<_>>();
+X 1 2 3"
+            .lines()
+            .collect::<Vec<_>>();
 
         let mut file = fs::File::open(filename).unwrap();
         let mut content = String::new();

--- a/src/trajectory.rs
+++ b/src/trajectory.rs
@@ -470,6 +470,7 @@ mod test {
 
     use super::*;
 
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn read() {
         let root = Path::new(file!()).parent().unwrap().join("..");


### PR DESCRIPTION
This makes paths be accepted as `AsRef<Path>` everywhere a `&str` was requested.

This should be merged after #37 (both change the same function).
Fix #32.