### PR TITLE
Decouple argument types in Trajectory::memory_reader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ mod frame;
 pub use self::frame::Frame;
 
 mod trajectory;
+pub use self::trajectory::MemoryTrajectoryReader;
 pub use self::trajectory::Trajectory;
 
 mod selection;


### PR DESCRIPTION
This allows things like

```rust
let data = if maybe_should_modify_string {
    maybe_modifies_string("cc")  // may sometimes allocate, so returns Cow<'_, str>
} else {
    "cc".into()
};
let _ = Trajectory::memory_reader(data, "SMI")?;
...
```

This should be merged after #36.
*Maybe* fix #31 (see https://github.com/chemfiles/chemfiles.rs/issues/31#issuecomment-1447047259).