### PR TITLE
Update to CMake>=3.16

### DIFF
--- a/chemfiles-sys/CMakeLists.txt
+++ b/chemfiles-sys/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.16)
 
 project(chemfiles-rust CXX)
 


### PR DESCRIPTION
v2.8.12 has been deprecated since the [release of cmake v3.19](https://cmake.org/cmake/help/latest/release/3.19.html#deprecated-and-removed-features) in 2020. so installing this package with cmake v3.19 or newer installed does not work.

i've tested building the application with cmake v4.0 after this modification